### PR TITLE
Pull request header integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ cache:
   yarn: true
   directories:
     - node_modules
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '7'
 
 script:
-  - yarn run check
+  - yarn run check-ci
 
 cache:
   yarn: true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "build": "better-npm-run build",
-    "check": "yarn run lint && yarn run test && yarn run flow && yarn run build",
+    "check": "yarn run lint && yarn run test && yarn run flow",
+    "check-ci": "yarn run check && yarn run build",
     "clean": "rm -rf static/dist",
     "dev": "concurrently --kill-others \"npm run watch-client\" \"npm run start-dev\"",
     "flow": "flow --show-all-errors; test $? -eq 0 -o $? -eq 2",

--- a/src/components/PullRequestSummary/PullRequestSummary.js
+++ b/src/components/PullRequestSummary/PullRequestSummary.js
@@ -1,8 +1,11 @@
+/* @flow */
+import moment from 'moment'
 import React, { PropTypes } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 
+import type { PullRequestGraphType } from 'ducks/pullRequest'
 import Reviewers from '../Reviewers'
-import TestAvatar from '../TestAvatar'
+import UserAvatar from '../UserAvatar'
 
 import { prReviewers } from '../../api/testPullRequest'
 
@@ -39,20 +42,42 @@ const headerColumnStyle = {
   paddingTop: '10px',
 }
 
-export const PullRequestHeader = () =>
+type PullRequestHeaderProps = {
+  pullRequest: PullRequestGraphType,
+}
+
+export const PullRequestHeader = ({ pullRequest } : PullRequestHeaderProps) =>
   <div style={{ display: 'inline-block' }}>
-    <TestAvatar />
+    <UserAvatar
+      src={pullRequest.owner.avatar}
+      style={{ float: 'left', display: 'table-column' }}
+    />
     <div style={{ padding: '0 10px', display: 'table' }}>
       <div style={{ fontSize: '16px' }}>
-        <strong>Core: cleanup and sanitize various hash functions we use internally V3</strong>
+        <strong>{pullRequest.title}</strong>
       </div>
-      <span style={{ color: 'grey', fontSize: '13px' }}>created 2 days ago</span>
+      <span style={{ color: 'grey', fontSize: '13px' }}>
+        created {moment(pullRequest.created).fromNow()}
+        by {pullRequest.owner.full_name} ({pullRequest.owner.username})
+      </span>
     </div>
   </div>
 
-const PullRequestSummary = (props) =>
+
+PullRequestHeader.propTypes = {
+  pullRequest: PropTypes.object.isRequired,
+}
+
+type PullRequestSummaryProps = {
+  onAddReviewer: Function,
+  onToggleReviewers: Function,
+  pullRequest: PullRequestGraphType,
+  toggleReviewers: boolean,
+}
+
+const PullRequestSummary = (props: PullRequestSummaryProps) =>
   <div name="summary" id="summary">
-    <PullRequestHeader />
+    <PullRequestHeader pullRequest={props.pullRequest} />
     <Row>
       <Col md={12}>
         <ListGroup style={{ marginTop: '20px', fontSize: '13px' }}>
@@ -201,7 +226,7 @@ const PullRequestSummary = (props) =>
                   </Col>
                   <Col md={11}>
                     <div style={{ fontSize: '13px' }}>
-                      {props.reviewers.join(', ')}
+                      {props.pullRequest.reviewers.map(r => r.user.full_name).join(', ')}
                     </div>
                   </Col>
                 </Row>
@@ -404,7 +429,7 @@ const PullRequestSummary = (props) =>
 PullRequestSummary.propTypes = {
   onAddReviewer: PropTypes.func.isRequired,
   onToggleReviewers: PropTypes.func.isRequired,
-  reviewers: PropTypes.arrayOf(PropTypes.string).isRequired,
+  pullRequest: PropTypes.object.isRequired,
   toggleReviewers: PropTypes.bool.isRequired,
 }
 

--- a/src/components/PullRequestSummary/PullRequestSummary.stories.js
+++ b/src/components/PullRequestSummary/PullRequestSummary.stories.js
@@ -1,9 +1,29 @@
 /* eslint-disable import/no-extraneous-dependencies */
+/* @flow */
 import React from 'react'
 import { storiesOf, action } from '@kadira/storybook'
 import { muiTheme } from 'storybook-addon-material-ui'
 
 import PullRequestSummary from './PullRequestSummary'
+
+const pullRequestFixture = {
+  title: 'New Test Pull requests',
+  status: 'new',
+  created: '2016-11-28 14:08:40.578150',
+  owner: {
+    avatar: null,
+    full_name: 'Kateryna Musina',
+    username: 'kateryna',
+  },
+  reviewers: [{
+    review_status: null,
+    user: {
+      avatar: null,
+      full_name: 'Sharron Bronson',
+      username: 'sharron',
+    },
+  }],
+}
 
 storiesOf('PullRequestSummary', module)
   .addDecorator(muiTheme())
@@ -11,7 +31,7 @@ storiesOf('PullRequestSummary', module)
     <PullRequestSummary
       onAddReviewer={action('onAddReviewer')}
       onToggleReviewers={action('onToggleReviewers')}
-      reviewers={['James Bond']}
+      pullRequest={pullRequestFixture}
       toggleReviewers={false}
     />
   ))

--- a/src/components/UserAvatar/UserAvatar.js
+++ b/src/components/UserAvatar/UserAvatar.js
@@ -1,18 +1,25 @@
+/* @flow */
 import React, { PropTypes } from 'react'
 import Avatar from 'material-ui/Avatar'
 
-function UserAvatar(props) {
+type Props = {
+  src: ?string,
+  style: ?Object,
+}
+
+function UserAvatar(props: Props) {
   return (
     <Avatar
       src={props.src}
       size={40}
-      style={{ borderRadius: '20%' }}
+      style={{ borderRadius: '20%', ...props.style }}
     />
   )
 }
 
 UserAvatar.propTypes = {
-  src: PropTypes.string.isRequired,
+  src: PropTypes.string,
+  style: PropTypes.object,
 }
 
 export default UserAvatar

--- a/src/components/UserAvatar/index.js
+++ b/src/components/UserAvatar/index.js
@@ -1,0 +1,2 @@
+import UserAvatar from './UserAvatar'
+export default UserAvatar

--- a/src/containers/Project/PullRequest/Layouts/LayoutDeveloper.js
+++ b/src/containers/Project/PullRequest/Layouts/LayoutDeveloper.js
@@ -1,7 +1,4 @@
-// TODO: add flow annotations
-/* eslint-disable max-len */
-
-import React, { Component } from 'react'
+import React, { Component, PropTypes } from 'react'
 import { Badge, Tabs, Tab } from 'react-bootstrap'
 import Scroll from 'react-scroll'
 
@@ -81,6 +78,7 @@ class LayoutDeveloper extends Component {
   }
 
   render() {
+    const { pullRequest } = this.props
     return (
       <div style={{ padding: '0 20px' }}>
         <Tabs defaultActiveKey={0} id="layout-developer-tabs">
@@ -88,19 +86,25 @@ class LayoutDeveloper extends Component {
             <PullRequestSummary
               onAddReviewer={this.addReviewer}
               onToggleReviewers={this.toggleReviewers}
-              reviewers={this.state.reviewers}
+              pullRequest={pullRequest}
               toggleReviewers={this.state.toggleReviewers}
             />
           </Tab>
           <Tab style={{ margin: '20px 0' }} eventKey={1} title={tabTitle('Discussion', 4)}>
-            <PullRequestDiscussion />
+            <PullRequestDiscussion
+              onSaveComment={() => {}}
+            />
           </Tab>
           <Tab style={{ margin: '20px 0' }} eventKey={2} title="Files">
             <div>
               <ChangesetFileList files={PullRequestData} />
             </div>
           </Tab>
-          <Tab style={{ margin: '20px 0' }} eventKey={3} title={tabTitle('Changesets', downloadIcon)}>
+          <Tab
+            style={{ margin: '20px 0' }}
+            eventKey={3}
+            title={tabTitle('Changesets', downloadIcon)}
+          >
             <div>
               <ChangesetGroupedList accordion={false} data={prChangesetList} />
             </div>
@@ -120,6 +124,10 @@ class LayoutDeveloper extends Component {
       </div>
     )
   }
+}
+
+LayoutDeveloper.propTypes = {
+  pullRequest: PropTypes.object.isRequired,
 }
 
 export default LayoutDeveloper

--- a/src/containers/Project/PullRequest/Layouts/LayoutGuardian.js
+++ b/src/containers/Project/PullRequest/Layouts/LayoutGuardian.js
@@ -1,5 +1,4 @@
 // TODO: add flow annotations
-/* eslint-disable max-len */
 
 import React, { Component } from 'react'
 import Scroll from 'react-scroll'
@@ -66,7 +65,6 @@ class LayoutGuardian extends Component {
             <PullRequestSummary
               onAddReviewer={this.addReviewer}
               onToggleReviewers={this.toggleReviewers}
-              reviewers={this.state.reviewers}
               toggleReviewers={this.state.toggleReviewers}
             />
           </div>
@@ -91,7 +89,9 @@ class LayoutGuardian extends Component {
         </Element>
         <Element name="discussion" className="element">
           <Divider text="Discussion" />
-          <PullRequestDiscussion />
+          <PullRequestDiscussion
+            onSaveComment={() => {}}
+          />
         </Element>
         <Element name="diff" className="element">
           <Divider text="Diff" />

--- a/src/containers/Project/PullRequest/index.js
+++ b/src/containers/Project/PullRequest/index.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import React, { PropTypes, Component } from 'react'
 import { connect } from 'react-redux'
 import Helmet from 'react-helmet'
@@ -8,51 +10,58 @@ import {
   DEVELOPER_PERSONA,
   MANAGER_PERSONA,
 } from 'ducks/session'
+import { actions } from 'ducks/pullRequest'
+import type { PullRequestGraphType } from 'ducks/pullRequest'
+
+import LoadingIcon from 'components/LoadingIcon'
 
 import LayoutDeveloper from './Layouts/LayoutDeveloper'
 import LayoutGuardian from './Layouts/LayoutGuardian'
 import StickyActionBar from './StickyActionBar'
 
-import { prDescription } from '../../../api/testData'
+type Props = {
+  dispatch: Function,
+  isFetching: boolean,
+  persona: DEVELOPER_PERSONA | MANAGER_PERSONA | GUARDIAN_PERSONA,
+  pullRequest: ?PullRequestGraphType,
+};
 
 class PullRequest extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      pullRequest: {
-        title: 'Some pull request title',
-        description: prDescription,
-        reviewers: ['Alex', 'NaTosha', 'Bob', 'John'],
-        from: 'default',
-        to: '5.3/default',
-        author: 'kate',
-        versions: ['link1', 'link2', 'link3'],
-        votes: {
-          accepted: 2,
-          rejected: 1,
-          pending: 1,
-        },
-      },
-    }
+
+  componentDidMount() {
+    const { dispatch } = this.props
+    console.log('>>> this props ', this.props);
+    // FIXME: we need to get this from the store, but currently it is not there...
+    const pullRequestId = parseInt(window.location.pathname.split('/').pop(), 10)
+    dispatch(actions.fetchStart(pullRequestId))
   }
 
+  props: Props;
+
   render() {
-    // const { params: { id }, theme, user, persona } = this.props
-    // const notOwner = user !== this.state.pullRequest.author
-    const { persona } = this.props
+    const { isFetching, pullRequest, persona } = this.props
+
+    if (isFetching) {
+      return <LoadingIcon />
+    }
+
+    if (!pullRequest) {
+      return <div>The requested pull request was not found...</div>
+    }
+
     return (
       <StickyContainer style={{ fontSize: '14px' }}>
-        <Helmet title="Pull Request Title" />
+        <Helmet title={`Pull Request: ${pullRequest.title}`} />
         <StickyActionBar />
         <div>
           {persona === DEVELOPER_PERSONA &&
-            <LayoutDeveloper />
+            <LayoutDeveloper pullRequest={pullRequest} />
           }
           {persona === MANAGER_PERSONA &&
-            <LayoutGuardian />
+            <LayoutGuardian pullRequest={pullRequest} />
           }
           {persona === GUARDIAN_PERSONA &&
-            <LayoutGuardian />
+            <LayoutGuardian pullRequest={pullRequest} />
           }
         </div>
       </StickyContainer>
@@ -60,18 +69,19 @@ class PullRequest extends Component {
   }
 }
 
+// TODO: remove .propTypes when parent also uses flow
 PullRequest.propTypes = {
- // isFetching: PropTypes.bool.isRequired,
- // errorMessage: PropTypes.string,
-  // params: PropTypes.object.isRequired,
-  // theme: PropTypes.object.isRequired,
-  // user: PropTypes.string,
+  dispatch: PropTypes.func.isRequired,
+  isFetching: PropTypes.bool.isRequired,
+  params: PropTypes.object.isRequired,
   persona: PropTypes.oneOf([DEVELOPER_PERSONA, MANAGER_PERSONA, GUARDIAN_PERSONA]).isRequired,
+  pullRequest: PropTypes.object,
 }
 
 export default connect(
   state => ({
-    isFetching: state.session.isFetching,
+    isFetching: state.pullRequest.isFetching,
     persona: state.session.persona,
+    pullRequest: state.pullRequest.pullRequest,
   })
 )(PullRequest)

--- a/src/containers/Project/PullRequest/index.js
+++ b/src/containers/Project/PullRequest/index.js
@@ -22,6 +22,10 @@ import StickyActionBar from './StickyActionBar'
 type Props = {
   dispatch: Function,
   isFetching: boolean,
+  params: {
+    id: string,
+    prid: string,
+  },
   persona: DEVELOPER_PERSONA | MANAGER_PERSONA | GUARDIAN_PERSONA,
   pullRequest: ?PullRequestGraphType,
 };
@@ -29,10 +33,8 @@ type Props = {
 class PullRequest extends Component {
 
   componentDidMount() {
-    const { dispatch } = this.props
-    console.log('>>> this props ', this.props);
-    // FIXME: we need to get this from the store, but currently it is not there...
-    const pullRequestId = parseInt(window.location.pathname.split('/').pop(), 10)
+    const { dispatch, params } = this.props
+    const pullRequestId = parseInt(params.prid, 10)
     dispatch(actions.fetchStart(pullRequestId))
   }
 
@@ -79,8 +81,9 @@ PullRequest.propTypes = {
 }
 
 export default connect(
-  state => ({
+  (state, ownProps) => ({
     isFetching: state.pullRequest.isFetching,
+    params: ownProps.params,
     persona: state.session.persona,
     pullRequest: state.pullRequest.pullRequest,
   })

--- a/src/containers/Project/PullRequest/index.js
+++ b/src/containers/Project/PullRequest/index.js
@@ -26,7 +26,7 @@ type Props = {
     id: string,
     prid: string,
   },
-  persona: DEVELOPER_PERSONA | MANAGER_PERSONA | GUARDIAN_PERSONA,
+  persona: 'DEVELOPER_PERSONA' | 'MANAGER_PERSONA' | 'GUARDIAN_PERSONA',
   pullRequest: ?PullRequestGraphType,
 };
 

--- a/src/ducks/index.js
+++ b/src/ducks/index.js
@@ -3,18 +3,21 @@
 import { combineReducers } from 'redux'
 import { routerReducer } from 'react-router-redux'
 import { reducer as formReducer } from 'redux-form'
-import projects from './projects'
-import session from './session'
-import pullrequests from './pullrequests'
-import sidebar from './sidebar'
+
 import breadcrumb from './breadcrumb'
+import projects from './projects'
+import pullRequest from './pullRequest'
+import pullrequests from './pullrequests'
+import session from './session'
+import sidebar from './sidebar'
 
 export default combineReducers({
-  projects,
-  sidebar,
   breadcrumb,
-  session,
-  pullrequests,
   form: formReducer,
+  projects,
+  pullRequest,
+  pullrequests,
   routing: routerReducer,
+  session,
+  sidebar,
 })

--- a/src/ducks/pullRequest/__tests__/index.js
+++ b/src/ducks/pullRequest/__tests__/index.js
@@ -1,0 +1,72 @@
+import reducer, { actions, types } from '../index'
+
+const expect = require('chai').expect
+
+const pullRequest = {
+  title: 'New Test Pull requests',
+  status: 'new',
+  created: '2016-11-28 14:08:40.578150',
+  owner: {
+    avatar: null,
+    full_name: 'Kateryna Musina',
+    username: 'kateryna',
+  },
+}
+
+describe('actions', () => {
+  it('should handle FETCH_START', () => {
+    const action = {
+      type: types.FETCH_START,
+      id: 10,
+    }
+    expect(actions.fetchStart(10)).to.eql(action)
+  })
+
+  it('should handle FETCH_ERROR', () => {
+    const error = 'test error'
+    const action = {
+      type: types.FETCH_ERROR,
+      error,
+    }
+    expect(actions.fetchError(error)).to.eql(action)
+  })
+
+  it('should handle FETCH_DONE', () => {
+    const action = {
+      type: types.FETCH_DONE,
+      pullRequest,
+    }
+    expect(actions.fetchDone(pullRequest)).to.eql(action)
+  })
+})
+
+
+describe('reducer', () => {
+  it('should return initial state', () => {
+    const initialState = {
+      error: null,
+      isFetching: false,
+      pullRequest: null,
+    }
+    expect(reducer(undefined, {})).to.eql(initialState)
+  })
+
+  it('should handle FETCH_ERROR', () => {
+    const error = 'error msg'
+    const expectedState = {
+      error,
+      isFetching: false,
+      pullRequest: null,
+    }
+    expect(reducer({}, actions.fetchError(error))).to.eql(expectedState)
+  })
+
+  it('should handle FETCH_DONE', () => {
+    const expectedState = {
+      error: null,
+      isFetching: false,
+      pullRequest,
+    }
+    expect(reducer({}, actions.fetchDone(pullRequest))).to.eql(expectedState)
+  })
+})

--- a/src/ducks/pullRequest/__tests__/index.js
+++ b/src/ducks/pullRequest/__tests__/index.js
@@ -22,6 +22,14 @@ describe('actions', () => {
     expect(actions.fetchStart(10)).to.eql(action)
   })
 
+  it('should handle FETCH_STATUS', () => {
+    const action = {
+      type: types.FETCH_STATUS,
+      isFetching: false,
+    }
+    expect(actions.fetchStatus(false)).to.eql(action)
+  })
+
   it('should handle FETCH_ERROR', () => {
     const error = 'test error'
     const action = {
@@ -51,12 +59,17 @@ describe('reducer', () => {
     expect(reducer(undefined, {})).to.eql(initialState)
   })
 
+  it('should handle FETCH_STATUS', () => {
+    const expectedState = {
+      isFetching: true,
+    }
+    expect(reducer({}, actions.fetchStatus(true))).to.eql(expectedState)
+  })
+
   it('should handle FETCH_ERROR', () => {
     const error = 'error msg'
     const expectedState = {
       error,
-      isFetching: false,
-      pullRequest: null,
     }
     expect(reducer({}, actions.fetchError(error))).to.eql(expectedState)
   })
@@ -64,7 +77,6 @@ describe('reducer', () => {
   it('should handle FETCH_DONE', () => {
     const expectedState = {
       error: null,
-      isFetching: false,
       pullRequest,
     }
     expect(reducer({}, actions.fetchDone(pullRequest))).to.eql(expectedState)

--- a/src/ducks/pullRequest/index.js
+++ b/src/ducks/pullRequest/index.js
@@ -4,6 +4,7 @@ export type { PullRequestGraphType } from 'services/ono/queries/pullRequest'
 
 export const types = {
   FETCH_START: 'PULLREQUEST/FETCH_START',
+  FETCH_STATUS: 'PULLREQUEST/FETCH_STATUS',
   FETCH_ERROR: 'PULLREQUEST/FETCH_ERROR',
   FETCH_DONE: 'PULLREQUEST/FETCH_DONE',
 }
@@ -22,6 +23,7 @@ export type PullRequestStateType = {
 
 export type PullRequestActionType =
     { type: 'PULLREQUEST/FETCH_START' }
+  | { type: 'PULLREQUEST/FETCH_STATUS', isFetching: boolean }
   | { type: 'PULLREQUEST/FETCH_ERROR', error: string }
   | { type: 'PULLREQUEST/FETCH_DONE', pullRequest: PullRequestGraphType }
 
@@ -29,22 +31,20 @@ export default (
   state: PullRequestStateType = initialState, action: PullRequestActionType
 ) => {
   switch (action.type) {
-    case types.FETCH_START:
+    case types.FETCH_STATUS:
       return {
-        error: null,
-        isFetching: true,
-        pullRequest: null,
+        ...state,
+        isFetching: action.isFetching,
       }
     case types.FETCH_ERROR:
       return {
+        ...state,
         error: action.error,
-        isFetching: false,
-        pullRequest: null,
       }
     case types.FETCH_DONE:
       return {
+        ...state,
         error: null,
-        isFetching: false,
         pullRequest: action.pullRequest,
       }
     default:
@@ -54,6 +54,7 @@ export default (
 
 export const actions = {
   fetchStart: (id: number) => ({ type: types.FETCH_START, id }),
+  fetchStatus: (isFetching: boolean) => ({ type: types.FETCH_STATUS, isFetching }),
   fetchError: (error: string) => ({ type: types.FETCH_ERROR, error }),
   fetchDone: (pullRequest: PullRequestGraphType) => ({ type: types.FETCH_DONE, pullRequest }),
 }

--- a/src/ducks/pullRequest/index.js
+++ b/src/ducks/pullRequest/index.js
@@ -1,0 +1,59 @@
+/* @flow */
+import type { PullRequestGraphType } from 'services/ono/queries/pullRequest'
+export type { PullRequestGraphType } from 'services/ono/queries/pullRequest'
+
+export const types = {
+  FETCH_START: 'PULLREQUEST/FETCH_START',
+  FETCH_ERROR: 'PULLREQUEST/FETCH_ERROR',
+  FETCH_DONE: 'PULLREQUEST/FETCH_DONE',
+}
+
+const initialState = {
+  error: null,
+  isFetching: false,
+  pullRequest: null,
+}
+
+export type PullRequestStateType = {
+  error: ?string,
+  isFetching: boolean,
+  pullRequest: ?PullRequestGraphType,
+}
+
+export type PullRequestActionType =
+    { type: 'PULLREQUEST/FETCH_START' }
+  | { type: 'PULLREQUEST/FETCH_ERROR', error: string }
+  | { type: 'PULLREQUEST/FETCH_DONE', pullRequest: PullRequestGraphType }
+
+export default (
+  state: PullRequestStateType = initialState, action: PullRequestActionType
+) => {
+  switch (action.type) {
+    case types.FETCH_START:
+      return {
+        error: null,
+        isFetching: true,
+        pullRequest: null,
+      }
+    case types.FETCH_ERROR:
+      return {
+        error: action.error,
+        isFetching: false,
+        pullRequest: null,
+      }
+    case types.FETCH_DONE:
+      return {
+        error: null,
+        isFetching: false,
+        pullRequest: action.pullRequest,
+      }
+    default:
+      return state
+  }
+}
+
+export const actions = {
+  fetchStart: (id: number) => ({ type: types.FETCH_START, id }),
+  fetchError: (error: string) => ({ type: types.FETCH_ERROR, error }),
+  fetchDone: (pullRequest: PullRequestGraphType) => ({ type: types.FETCH_DONE, pullRequest }),
+}

--- a/src/ducks/session/index.js
+++ b/src/ducks/session/index.js
@@ -1,4 +1,4 @@
-// TODO: add flow annotations
+/* @flow */
 
 /**
  * Action types

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,23 +1,27 @@
-// TODO: add flow annotations, see https://github.com/flowtype/flow-typed
+/* @flow */
 
 import { fork } from 'redux-saga/effects'
 import { takeLatest } from 'redux-saga'
 import { types as sessionTypes } from 'ducks/session'
-import { types as prTypes } from 'ducks/pullrequests'
+import { types as prsTypes } from 'ducks/pullrequests'
+import { types as prTypes } from 'ducks/pullRequest'
 import fetchCurrentUserProfile from './session'
 import {
   fetchCurrentUserPullRequests,
   fetchCurrentUserAssignedPullRequests,
   fetchCurrentUserWatchingPullRequests,
 } from './pullrequests'
+import fetchPullRequest from './pullRequest'
 
-export default function* rootSaga() {
+export default function* rootSaga(): Generator<*, *, *> {
   yield fork(
     takeLatest, sessionTypes.FETCH_USER_PROFILE, fetchCurrentUserProfile)
   yield fork(
-    takeLatest, prTypes.FETCH_USER_PULL_REQUESTS, fetchCurrentUserPullRequests)
+    takeLatest, prsTypes.FETCH_USER_PULL_REQUESTS, fetchCurrentUserPullRequests)
   yield fork(
-    takeLatest, prTypes.FETCH_USER_ASSIGNED_PULL_REQUESTS, fetchCurrentUserAssignedPullRequests)
+    takeLatest, prsTypes.FETCH_USER_ASSIGNED_PULL_REQUESTS, fetchCurrentUserAssignedPullRequests)
   yield fork(
-    takeLatest, prTypes.FETCH_USER_WATCHING_PULL_REQUESTS, fetchCurrentUserWatchingPullRequests)
+    takeLatest, prsTypes.FETCH_USER_WATCHING_PULL_REQUESTS, fetchCurrentUserWatchingPullRequests)
+  yield fork(
+    takeLatest, prTypes.FETCH_START, fetchPullRequest)
 }

--- a/src/sagas/pullRequest/__tests__/index.js
+++ b/src/sagas/pullRequest/__tests__/index.js
@@ -1,0 +1,74 @@
+/* @flow */
+import { call, put } from 'redux-saga/effects'
+
+import { actions } from 'ducks/pullRequest'
+import PULL_REQUEST_QUERY from 'services/ono/queries/pullRequest'
+import { get } from 'services/ono/api'
+import fetchPullRequest from '../index'
+
+const expect = require('chai').expect
+
+const pullRequestResponse = {
+  title: 'New Test Pull requests',
+  status: 'new',
+  created: '2016-11-28 14:08:40.578150',
+  owner: {
+    avatar: null,
+    full_name: 'Kateryna Musina',
+    username: 'kateryna',
+  },
+  reviewers: {
+    edges: [
+      {
+        node: {
+          review_status: null,
+          user: {
+            avatar: null,
+            full_name: 'Sharron Bronson',
+            username: 'sharron',
+          },
+        },
+      },
+    ],
+  },
+}
+
+const pullRequestResponseParsed = {
+  title: 'New Test Pull requests',
+  status: 'new',
+  created: '2016-11-28 14:08:40.578150',
+  owner: {
+    avatar: null,
+    full_name: 'Kateryna Musina',
+    username: 'kateryna',
+  },
+  reviewers: [{
+    review_status: null,
+    user: {
+      avatar: null,
+      full_name: 'Sharron Bronson',
+      username: 'sharron',
+    },
+  }],
+}
+
+
+describe('fetchPullRequest saga', () => {
+  it('fetches', () => {
+    const generator = fetchPullRequest({ type: 'foo', id: 10 })
+    const queryResponse = { data: { pull_request: pullRequestResponse } }
+
+    expect(generator.next().value)
+      .to.deep.equal(call(get, PULL_REQUEST_QUERY, { id: 10 }))
+    expect(generator.next(queryResponse).value)
+      .to.deep.equal(put(actions.fetchDone(pullRequestResponseParsed)))
+  })
+
+  it('catches exception', () => {
+    const generator = fetchPullRequest({ type: 'foo', id: 11 })
+    const error = 'TEST ERROR fetchUserProfile'
+
+    expect(generator.next().value).to.deep.equal(call(get, PULL_REQUEST_QUERY, { id: 11 }))
+    expect(generator.throw(error).value).to.deep.equal(put(actions.fetchError(error)))
+  })
+})

--- a/src/sagas/pullRequest/__tests__/index.js
+++ b/src/sagas/pullRequest/__tests__/index.js
@@ -59,16 +59,26 @@ describe('fetchPullRequest saga', () => {
     const queryResponse = { data: { pull_request: pullRequestResponse } }
 
     expect(generator.next().value)
+      .to.deep.equal(put(actions.fetchStatus(true)))
+    expect(generator.next().value)
       .to.deep.equal(call(get, PULL_REQUEST_QUERY, { id: 10 }))
     expect(generator.next(queryResponse).value)
       .to.deep.equal(put(actions.fetchDone(pullRequestResponseParsed)))
+    expect(generator.next().value)
+        .to.deep.equal(put(actions.fetchStatus(false)))
   })
 
   it('catches exception', () => {
     const generator = fetchPullRequest({ type: 'foo', id: 11 })
     const error = 'TEST ERROR fetchUserProfile'
 
-    expect(generator.next().value).to.deep.equal(call(get, PULL_REQUEST_QUERY, { id: 11 }))
-    expect(generator.throw(error).value).to.deep.equal(put(actions.fetchError(error)))
+    expect(generator.next().value)
+      .to.deep.equal(put(actions.fetchStatus(true)))
+    expect(generator.next().value)
+      .to.deep.equal(call(get, PULL_REQUEST_QUERY, { id: 11 }))
+    expect(generator.throw(error).value)
+      .to.deep.equal(put(actions.fetchError(error)))
+    expect(generator.next().value)
+      .to.deep.equal(put(actions.fetchStatus(false)))
   })
 })

--- a/src/sagas/pullRequest/index.js
+++ b/src/sagas/pullRequest/index.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+import { call, put } from 'redux-saga/effects'
+
+import { actions } from 'ducks/pullRequest'
+import PULL_REQUEST_QUERY, { parsers } from 'services/ono/queries/pullRequest'
+import { get } from 'services/ono/api'
+
+type Action = { type: string, id: number }
+
+export default function* fetchPullRequest(action: Action): Generator<*, *, *> {
+  try {
+    const response = yield call(get, PULL_REQUEST_QUERY, { id: action.id })
+    const pullRequest = parsers.pullRequestQuery(response)
+    yield put(actions.fetchDone(pullRequest))
+  } catch (error) {
+    yield put(actions.fetchError(error))
+  }
+}

--- a/src/sagas/pullRequest/index.js
+++ b/src/sagas/pullRequest/index.js
@@ -9,11 +9,14 @@ import { get } from 'services/ono/api'
 type Action = { type: string, id: number }
 
 export default function* fetchPullRequest(action: Action): Generator<*, *, *> {
+  yield put(actions.fetchStatus(true))
   try {
     const response = yield call(get, PULL_REQUEST_QUERY, { id: action.id })
     const pullRequest = parsers.pullRequestQuery(response)
     yield put(actions.fetchDone(pullRequest))
   } catch (error) {
     yield put(actions.fetchError(error))
+  } finally {
+    yield put(actions.fetchStatus(false))
   }
 }

--- a/src/services/ono/api/index.js
+++ b/src/services/ono/api/index.js
@@ -24,12 +24,14 @@ import { checkHttpStatus, parseJSON } from 'universal/requests'
  * @param  {[type]} query - accepts the FormData object
  * @return {[type]}      [description]
  */
-export function get(query: string): Object {
+export function get(query: string, variables: any) {
   const encodedQuery = encodeURIComponent(query)
-  const url = `${routes.ONO_API_ROUTE}?query=${encodedQuery}`
-
+  let variablesPostFix = ''
+  if (variables) {
+    variablesPostFix = `&variables=${encodeURIComponent(JSON.stringify(variables))}`
+  }
+  const url = `${routes.ONO_API_ROUTE}?query=${encodedQuery}${variablesPostFix}`
   return fetch(url, { credentials: 'same-origin' })
     .then(checkHttpStatus)
     .then(parseJSON)
 }
-

--- a/src/services/ono/queries/pullRequest/index.js
+++ b/src/services/ono/queries/pullRequest/index.js
@@ -1,0 +1,62 @@
+/* @flow */
+
+const PULL_REQUEST_QUERY = `
+query ($id: Int!) {
+  pull_request(id: $id) {
+    title
+    status
+    created
+    owner {
+      avatar(size: 40)
+      full_name
+      username
+    }
+    reviewers {
+      edges {
+        node {
+          review_status
+          user {
+            avatar(size: 40)
+            full_name
+            username
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+export default PULL_REQUEST_QUERY
+
+export const parsers = {
+  // TODO: this could be done by the fetch function...
+  // Pretty simple transformation
+  pullRequestQuery: (response: any) => (
+    Object.assign(
+      {},
+      response.data.pull_request,
+      { reviewers: response.data.pull_request.reviewers.edges.map(e => e.node) }
+    )
+  ),
+}
+
+export type PullRequestUserType = {
+  username: string,
+  full_name: string,
+  avatar: ?string,
+}
+
+export type PullRequestReviewerType = {
+  review_status: ?string,
+  user: PullRequestUserType
+}
+
+// TODO: this can be automatically extracted from schema
+export type PullRequestGraphType = {
+  title: string,
+  status: string,
+  created: string,
+  owner: PullRequestUserType,
+  reviewers: Array<PullRequestReviewerType>
+}

--- a/webpack/config.dev.js
+++ b/webpack/config.dev.js
@@ -32,7 +32,7 @@ module.exports = Object.assign({}, baseConfig, {
     loaders: [{
       test: /\.(js|jsx)$/,
       exclude: /node_modules/,
-      loaders: ['babel?' + JSON.stringify(config), 'eslint-loader']
+      loaders: ['babel?' + JSON.stringify(config)]
     },
       {
         test: /\.json$/,


### PR DESCRIPTION
This PR includes saga, ducks and graphql queries for showing the header of a specific pull request. 

I've tried to add flow annotations in all layers of the application and it really helps when moving between the different layers.

The user avatar is still broken in the graphql endpoint. But currently we just show an empty avatar.

Please review @kkateq 