### PR TITLE
Flow all over

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,8 @@
     "no-unused-vars": ["error", { "args": "none" }],
     "import/extensions": "off",
     "no-duplicate-imports": "off",
-    "max-len": ["error", 100]
+    "max-len": ["error", 100],
+    "react/prop-types": "off"
   },
   "globals": {
     "__DEVELOPMENT__": true,

--- a/.flowconfig
+++ b/.flowconfig
@@ -6,7 +6,6 @@
 <PROJECT_ROOT>/node_modules/config-chain/*
 <PROJECT_ROOT>/node_modules/draft-js/*
 
-<PROJECT_ROOT>/src/components/CodeDiffView
 
 
 [include]

--- a/src/components/BranchSelect/index.js
+++ b/src/components/BranchSelect/index.js
@@ -1,5 +1,7 @@
+// TODO: finish flow annotation
+
 import Select from 'react-select'
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import 'react-select/dist/react-select.css'
 import './styles.css'
 
@@ -11,7 +13,7 @@ export type Props = {
   disabled?: boolean,
   placeholder?: string,
   branches: Array<any>,
-};
+}
 
 class BranchSelect extends Component {
   constructor(props: Props) {
@@ -21,7 +23,7 @@ class BranchSelect extends Component {
     this.renderValue = this.renderValue.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleChange(value) {
     this.setState({

--- a/src/components/BranchSelect/index.js
+++ b/src/components/BranchSelect/index.js
@@ -3,13 +3,25 @@ import React, { Component, PropTypes } from 'react'
 import 'react-select/dist/react-select.css'
 import './styles.css'
 
+export type Props = {
+  project: string,
+  defaultValue?: string,
+  onChange?: Function,
+  prefix?: string,
+  disabled?: boolean,
+  placeholder?: string,
+  branches: Array<any>,
+};
+
 class BranchSelect extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { project: props.project, value: props.defaultValue }
     this.handleChange = this.handleChange.bind(this)
     this.renderValue = this.renderValue.bind(this)
   }
+
+  props: Props;
 
   handleChange(value) {
     this.setState({
@@ -41,16 +53,6 @@ class BranchSelect extends Component {
       </div>
     )
   }
-}
-
-BranchSelect.propTypes = {
-  project: PropTypes.string.isRequired,
-  defaultValue: PropTypes.string,
-  onChange: PropTypes.func,
-  prefix: PropTypes.string,
-  disabled: PropTypes.bool,
-  placeholder: PropTypes.string,
-  branches: PropTypes.array.isRequired,
 }
 
 export default BranchSelect

--- a/src/components/ChangesetDelta/ChangesetDelta.js
+++ b/src/components/ChangesetDelta/ChangesetDelta.js
@@ -1,31 +1,24 @@
-export type Props = {
-  deleted?: number,
-  changed?: number,
-  added?: number,
-  showDetails?: boolean,
-};
-
 /* @flow */
-import React, { PropTypes } from 'react'
+import React from 'react'
 import './ChangesetDelta.css'
 
 type ChangesetDeltaProps = {
   deleted: number,
   added: number,
   changed: number,
-  showDetails: boolean,
+  showDetails?: boolean,
 }
 
-function gerPercent(sum: number, value: number) {
+function getPercent(sum: number, value: number) {
   return sum > 0 ? Math.round((100 * value) / sum) : 0
 }
 
 const ChangesetDelta = ({ added, deleted, changed, showDetails }: ChangesetDeltaProps) => {
   const sum = deleted + added + changed
 
-  const deletedPercent = gerPercent(sum, deleted)
-  const addedPercent = gerPercent(sum, added)
-  const changedPercent = gerPercent(sum, changed)
+  const deletedPercent = getPercent(sum, deleted)
+  const addedPercent = getPercent(sum, added)
+  const changedPercent = getPercent(sum, changed)
 
   return (
     <div className="changeset-delta">
@@ -54,6 +47,5 @@ const ChangesetDelta = ({ added, deleted, changed, showDetails }: ChangesetDelta
   )
 }
 
-;
 
 export default ChangesetDelta

--- a/src/components/ChangesetDelta/ChangesetDelta.js
+++ b/src/components/ChangesetDelta/ChangesetDelta.js
@@ -1,3 +1,10 @@
+export type Props = {
+  deleted?: number,
+  changed?: number,
+  added?: number,
+  showDetails?: boolean,
+};
+
 /* @flow */
 import React, { PropTypes } from 'react'
 import './ChangesetDelta.css'
@@ -47,11 +54,6 @@ const ChangesetDelta = ({ added, deleted, changed, showDetails }: ChangesetDelta
   )
 }
 
-ChangesetDelta.propTypes = {
-  deleted: PropTypes.number.isRequired,
-  changed: PropTypes.number.isRequired,
-  added: PropTypes.number.isRequired,
-  showDetails: PropTypes.bool,
-}
+;
 
 export default ChangesetDelta

--- a/src/components/ChangesetDelta/index.js
+++ b/src/components/ChangesetDelta/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import ChangesetDelta from './ChangesetDelta'
 export default ChangesetDelta

--- a/src/components/ChangesetFileList/ChangesetFileList.js
+++ b/src/components/ChangesetFileList/ChangesetFileList.js
@@ -1,114 +1,127 @@
-import React, { PropTypes, Component } from 'react'
-import { ChangesetDelta } from 'components'
+/* @flow */
+import React, { PropTypes } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 import Scroll from 'react-scroll'
 import _ from 'lodash'
+
+import ChangesetDelta from '../ChangesetDelta'
 
 import './ChangesetFileList.css'
 
 const Link = Scroll.Link
 
-class ChangesetFileList extends Component {
-  constructor(props) {
-    super(props)
-    this.state = { search: null }
-  }
-
-  render() {
-    const { containerId } = this.props
-
-    return (
-      <div>
-        <Row>
-          <Col md={12}>
-            <div
-              style={{
-                display: 'inline-flex',
-                border: '1px solid lightgrey',
-                borderRadius: '5px',
-                padding: '7px',
-                width: '100%',
-              }}
-            >
-              <span style={{ pagging: '10px', color: 'grey' }}>
-                <i className="fa fa-search" aria-hidden="true" />
-              </span>
-              <input
-                type="text"
-                style={{
-                  outline: 'none',
-                  border: 'none',
-                  marginLeft: '10px',
-                  fontSize: '14px',
-                  width: '100%' }}
-              />
-            </div>
-            <div style={{ color: 'rgb(122, 123, 123)', fontSize: '12px', padding: '10px' }} active>
-            225 files changed with 1871 insertions and 8737 deletions
-            </div>
-          </Col>
-        </Row>
-
-        <Row>
-          <Col md={12}>
-            <ListGroup style={{ fontSize: '13px', overflowY: 'auto', overflowX: 'hidden' }}>
-              {this.props.files.map(file => (
-                <ListGroupItem key={_.uniqueId('listItem')} style={{ padding: '10px 10px' }} >
-                  <Row>
-                    {!this.props.compact &&
-                      <Col lg={2} md={2} xsHidden smHidden>
-                        <ChangesetDelta
-                          deleted={Math.floor((Math.random() * 10) + 1)}
-                          added={Math.floor((Math.random() * 10) + 1)}
-                          changed={Math.floor((Math.random() * 10) + 1)}
-                        />
-
-                      </Col>
-                    }
-                    <Col lg={8} md={8} sm={8} xs={8}>
-                      <div>
-                        <Link
-                          style={{ cursor: 'pointer' }}
-                          containerId={containerId}
-                          activeClass="active"
-                          to={file.name.replace(/[/.]/g, '')}
-                          spy
-                          smooth
-                          duration={100}
-                        >
-                          {file.name}
-                        </Link>
-                      </div>
-                    </Col>
-                    <Col
-                      lg={this.props.compact ? 4 : 2}
-                      md={this.props.compact ? 4 : 2}
-                      sm={this.props.compact ? 4 : 2}
-                      xs={this.props.compact ? 4 : 2}
-                    >
-                    {file.comments.length > 0 &&
-                      <div style={{ color: 'lightblue', cursor: 'pointer', float: 'right' }}>
-                        <span style={{ marginRight: '5px' }}>
-                          <i className="fa fa-comment" aria-hidden="true" />
-                        </span>
-                        {file.comments.length}
-                      </div>
-                    }
-                    </Col>
-                  </Row>
-                </ListGroupItem>))}
-            </ListGroup>
-          </Col>
-        </Row>
-      </div>
-    )
-  }
+type ChangeSetFileCommentType = {
+  id: string,
+  message: string,
 }
 
+type ChangeSetFileType = {
+  comments: Array<ChangeSetFileCommentType>,
+  name: string,
+}
+
+type Props = {
+  containerId: string,
+  files: Array<ChangeSetFileType>,
+  compact: boolean,
+}
+
+const ChangesetFileList = ({ containerId, compact, files }: Props) =>
+  <div>
+    <Row>
+      <Col md={12}>
+        <div
+          style={{
+            display: 'inline-flex',
+            border: '1px solid lightgrey',
+            borderRadius: '5px',
+            padding: '7px',
+            width: '100%',
+          }}
+        >
+          <span style={{ pagging: '10px', color: 'grey' }}>
+            <i className="fa fa-search" aria-hidden="true" />
+          </span>
+          <input
+            type="text"
+            style={{
+              outline: 'none',
+              border: 'none',
+              marginLeft: '10px',
+              fontSize: '14px',
+              width: '100%' }}
+          />
+        </div>
+        <div style={{ color: 'rgb(122, 123, 123)', fontSize: '12px', padding: '10px' }} active>
+        225 files changed with 1871 insertions and 8737 deletions
+        </div>
+      </Col>
+    </Row>
+
+    <Row>
+      <Col md={12}>
+        <ListGroup style={{ fontSize: '13px', overflowY: 'auto', overflowX: 'hidden' }}>
+          {files.map(file => (
+            <ListGroupItem key={_.uniqueId('listItem')} style={{ padding: '10px 10px' }} >
+              <Row>
+                {!compact &&
+                  <Col lg={2} md={2} xsHidden smHidden>
+                    <ChangesetDelta
+                      deleted={Math.floor((Math.random() * 10) + 1)}
+                      added={Math.floor((Math.random() * 10) + 1)}
+                      changed={Math.floor((Math.random() * 10) + 1)}
+                    />
+
+                  </Col>
+                }
+                <Col lg={8} md={8} sm={8} xs={8}>
+                  <div>
+                    {file.name}
+                    {
+                    // FIXME:
+                    // <Link
+                    //   style={{ cursor: 'pointer' }}
+                    //   containerId={containerId}
+                    //   activeClass="active"
+                    //   to={file.name.replace(/[/.]/g, '')}
+                    //   spy
+                    //   smooth
+                    //   duration={100}
+                    // >
+                    //   {file.name}
+                    // </Link>
+                    }
+                  </div>
+                </Col>
+                <Col
+                  lg={compact ? 4 : 2}
+                  md={compact ? 4 : 2}
+                  sm={compact ? 4 : 2}
+                  xs={compact ? 4 : 2}
+                >
+                {file.comments.length > 0 &&
+                  <div style={{ color: 'lightblue', cursor: 'pointer', float: 'right' }}>
+                    <span style={{ marginRight: '5px' }}>
+                      <i className="fa fa-comment" aria-hidden="true" />
+                    </span>
+                    {file.comments.length}
+                  </div>
+                }
+                </Col>
+              </Row>
+            </ListGroupItem>))}
+        </ListGroup>
+      </Col>
+    </Row>
+  </div>
+
 ChangesetFileList.propTypes = {
-  files: PropTypes.array,
-  compact: PropTypes.bool,
-  containerId: PropTypes.string,
+  compact: PropTypes.bool.isRequired,
+  containerId: PropTypes.string.isRequired,
+  files: PropTypes.arrayOf(React.PropTypes.shape({
+    comments: PropTypes.array.isRequired,
+    name: PropTypes.string.isRequired,
+  })).isRequired,
 }
 
 export default ChangesetFileList

--- a/src/components/ChangesetFileList/ChangesetFileList.js
+++ b/src/components/ChangesetFileList/ChangesetFileList.js
@@ -1,3 +1,12 @@
+export type Props = {
+  compact?: boolean,
+  containerId?: string,
+  files?: Array<{
+    comments?: Array<any>,
+    name?: string,
+  }>,
+};
+
 /* @flow */
 import React, { PropTypes } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
@@ -115,13 +124,6 @@ const ChangesetFileList = ({ containerId, compact, files }: Props) =>
     </Row>
   </div>
 
-ChangesetFileList.propTypes = {
-  compact: PropTypes.bool.isRequired,
-  containerId: PropTypes.string.isRequired,
-  files: PropTypes.arrayOf(React.PropTypes.shape({
-    comments: PropTypes.array.isRequired,
-    name: PropTypes.string.isRequired,
-  })).isRequired,
-}
+;
 
 export default ChangesetFileList

--- a/src/components/ChangesetFileList/ChangesetFileList.js
+++ b/src/components/ChangesetFileList/ChangesetFileList.js
@@ -1,23 +1,11 @@
-export type Props = {
-  compact?: boolean,
-  containerId?: string,
-  files?: Array<{
-    comments?: Array<any>,
-    name?: string,
-  }>,
-};
-
 /* @flow */
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
-import Scroll from 'react-scroll'
 import _ from 'lodash'
 
 import ChangesetDelta from '../ChangesetDelta'
 
 import './ChangesetFileList.css'
-
-const Link = Scroll.Link
 
 type ChangeSetFileCommentType = {
   id: string,
@@ -30,12 +18,11 @@ type ChangeSetFileType = {
 }
 
 type Props = {
-  containerId: string,
   files: Array<ChangeSetFileType>,
-  compact: boolean,
+  compact?: boolean,
 }
 
-const ChangesetFileList = ({ containerId, compact, files }: Props) =>
+const ChangesetFileList = ({ compact, files }: Props) =>
   <div>
     <Row>
       <Col md={12}>
@@ -124,6 +111,5 @@ const ChangesetFileList = ({ containerId, compact, files }: Props) =>
     </Row>
   </div>
 
-;
 
 export default ChangesetFileList

--- a/src/components/ChangesetFileList/ChangesetFileList.stories.js
+++ b/src/components/ChangesetFileList/ChangesetFileList.stories.js
@@ -1,0 +1,39 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* @flow */
+import React from 'react'
+import { storiesOf } from '@kadira/storybook'
+import { muiTheme } from 'storybook-addon-material-ui'
+
+import ChangesetFileList from './ChangesetFileList'
+
+const fixtureComments = [
+  {
+    id: 'comment1',
+    message: 'foo bar',
+  },
+  {
+    id: 'comment1',
+    message: 'foo bar baz',
+  },
+]
+
+const filesFixture = [
+  {
+    name: 'Editor/Mono/EditorGUI.cs',
+    comments: fixtureComments,
+  },
+  {
+    name: 'Editor/Mono/GUI/GradientEditor.cs',
+    comments: [],
+  },
+]
+
+storiesOf('ChangesetFileList', module)
+  .addDecorator(muiTheme())
+  .add('compact', () => (
+    <ChangesetFileList
+      compact
+      containerId={'foo'}
+      files={filesFixture}
+    />
+  ))

--- a/src/components/ChangesetFileList/index.js
+++ b/src/components/ChangesetFileList/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import ChangesetFileList from './ChangesetFileList'
 export default ChangesetFileList

--- a/src/components/ChangesetGroupedList/ChangesetGroupedList.js
+++ b/src/components/ChangesetGroupedList/ChangesetGroupedList.js
@@ -1,6 +1,8 @@
+// TODO: add flow annotation
+
 /* eslint-disable max-len */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { Col, Row, PanelGroup, Panel } from 'react-bootstrap'
 import { ChangesetList } from 'components'
 import _ from 'lodash'
@@ -8,9 +10,9 @@ import _ from 'lodash'
 import './ChangesetGroupedList.css'
 
 export type Props = {
-  data?: any,
-  accordion?: boolean,
-};
+  data: any,
+  accordion: boolean,
+}
 
 class ChangesetGroupedList extends Component {
   constructor(props: Props) {
@@ -19,7 +21,7 @@ class ChangesetGroupedList extends Component {
     this.handleSelect = this.handleSelect.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleSelect(activeKey) {
     this.setState({ activeKey })

--- a/src/components/ChangesetGroupedList/ChangesetGroupedList.js
+++ b/src/components/ChangesetGroupedList/ChangesetGroupedList.js
@@ -7,12 +7,19 @@ import _ from 'lodash'
 
 import './ChangesetGroupedList.css'
 
+export type Props = {
+  data?: any,
+  accordion?: boolean,
+};
+
 class ChangesetGroupedList extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { search: null, activeKey: 3 }
     this.handleSelect = this.handleSelect.bind(this)
   }
+
+  props: Props;
 
   handleSelect(activeKey) {
     this.setState({ activeKey })
@@ -101,11 +108,6 @@ class ChangesetGroupedList extends Component {
       </div>
     )
   }
-}
-
-ChangesetGroupedList.propTypes = {
-  data: PropTypes.any,
-  accordion: PropTypes.bool,
 }
 
 export default ChangesetGroupedList

--- a/src/components/ChangesetGroupedList/index.js
+++ b/src/components/ChangesetGroupedList/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+import ChangesetGroupedList from './ChangesetGroupedList'
+export default ChangesetGroupedList

--- a/src/components/ChangesetList/ChangesetList.js
+++ b/src/components/ChangesetList/ChangesetList.js
@@ -16,13 +16,21 @@ const subHeader = text => (
   </div>
 )
 
+export type Props = {
+  data?: any,
+  compact?: boolean,
+  showCheckboxes?: boolean,
+};
+
 class ChangesetList extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { search: null, activeKey: 3, changesets: [] }
     this.handleSelect = this.handleSelect.bind(this)
     this.handleChange = this.handleChange.bind(this)
   }
+
+  props: Props;
 
   handleSelect(activeKey) {
     this.setState({ activeKey })
@@ -153,12 +161,6 @@ class ChangesetList extends Component {
       </ListGroup>
     )
   }
-}
-
-ChangesetList.propTypes = {
-  data: PropTypes.any,
-  compact: PropTypes.bool,
-  showCheckboxes: PropTypes.bool,
 }
 
 export default ChangesetList

--- a/src/components/ChangesetList/ChangesetList.js
+++ b/src/components/ChangesetList/ChangesetList.js
@@ -1,7 +1,7 @@
 // todo: remove this after refactoring component
 /* eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 import { ChangesetDelta, TestAvatar } from 'components'
 import { Link } from 'react-router'
@@ -20,7 +20,7 @@ export type Props = {
   data?: any,
   compact?: boolean,
   showCheckboxes?: boolean,
-};
+}
 
 class ChangesetList extends Component {
   constructor(props: Props) {
@@ -30,7 +30,7 @@ class ChangesetList extends Component {
     this.handleChange = this.handleChange.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleSelect(activeKey) {
     this.setState({ activeKey })

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -2,8 +2,16 @@ import React, { Component, PropTypes } from 'react'
 
 import './Checkbox.css'
 
+export type Props = {
+  value: string,
+  onCheck?: Function,
+  name: string,
+  checked?: boolean,
+  disabled?: boolean,
+};
+
 class Checkbox extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       value: this.props.value,
@@ -13,6 +21,8 @@ class Checkbox extends Component {
     this.handleClick = this.handleClick.bind(this)
   }
 
+  props: Props;
+
   handleClick(e) {
     this.setState({ checked: e.target.checked })
     if (this.props.onCheck) {
@@ -20,7 +30,7 @@ class Checkbox extends Component {
     }
   }
 
-// TODO: apply material-ui  styling here
+  // TODO: apply material-ui  styling here
   render() {
     const { value, checked, disabled } = this.state
     const { name } = this.props
@@ -39,14 +49,6 @@ class Checkbox extends Component {
       </div>
     )
   }
-}
-
-Checkbox.propTypes = {
-  value: PropTypes.string.isRequired,
-  onCheck: PropTypes.func,
-  name: PropTypes.string.isRequired,
-  checked: PropTypes.bool,
-  disabled: PropTypes.bool,
 }
 
 export default Checkbox

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -1,4 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+// TODO: add flow annotation
+
+import React, { Component } from 'react'
 
 import './Checkbox.css'
 
@@ -8,7 +10,7 @@ export type Props = {
   name: string,
   checked?: boolean,
   disabled?: boolean,
-};
+}
 
 class Checkbox extends Component {
   constructor(props: Props) {
@@ -21,7 +23,7 @@ class Checkbox extends Component {
     this.handleClick = this.handleClick.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleClick(e) {
     this.setState({ checked: e.target.checked })

--- a/src/components/CodeDiffView/Code/Code.js
+++ b/src/components/CodeDiffView/Code/Code.js
@@ -16,6 +16,15 @@ import {
 } from '../PrismCodeParser/PrismCodeParser'
 
 
+export type Props = {
+  type: string,
+  diff: string,
+  comments?: Array<any>,
+  collapseComments?: boolean,
+  viewType?: string,
+};
+
+
 class Code extends Component {
   asyncProcessCode({ type, viewType, diff }) {
     const promise = new Promise((resolve) => {
@@ -48,7 +57,7 @@ class Code extends Component {
     return []
   }
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       ready: false,
@@ -62,6 +71,8 @@ class Code extends Component {
     this.getFileComments = this.getFileComments.bind(this)
     this.updateCode = this.updateCode.bind(this)
   }
+
+  props: Props;
 
   componentWillMount() {
     this.asyncProcessCode(this.props).then(this.updateCode)
@@ -143,14 +154,6 @@ class Code extends Component {
       </div>
     )
   }
-}
-
-Code.propTypes = {
-  type: PropTypes.string.isRequired,
-  diff: PropTypes.string.isRequired,
-  comments: PropTypes.array,
-  collapseComments: PropTypes.bool,
-  viewType: PropTypes.string,
 }
 
 export default Code

--- a/src/components/CodeDiffView/Code/Code.js
+++ b/src/components/CodeDiffView/Code/Code.js
@@ -1,8 +1,7 @@
-/* @flow */
-
+// TODO: finish flow annotations
 /* eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import Prism from 'prismjs'
 import { ErrorMessage } from 'components'
 import _ from 'lodash'
@@ -72,7 +71,7 @@ class Code extends Component {
     this.updateCode = this.updateCode.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   componentWillMount() {
     this.asyncProcessCode(this.props).then(this.updateCode)

--- a/src/components/CodeDiffView/CodeDiffView.js
+++ b/src/components/CodeDiffView/CodeDiffView.js
@@ -8,7 +8,9 @@ import _ from 'lodash'
 import { Row, Col, Tab, Tabs } from 'react-bootstrap'
 import Select from 'react-select'
 import 'react-select/dist/react-select.css'
-import { ChangesetFileList, CommentsList } from 'components'
+
+import ChangesetFileList from '../ChangesetFileList'
+import CommentsList from '../CommentsList'
 
 import DiffHeader from './DiffHeader/DiffHeader'
 import { PullRequestData, PullRequestHistory2, PullRequestUnresolvedComments } from '../../api/testPullRequest'

--- a/src/components/CodeDiffView/CodeDiffView.js
+++ b/src/components/CodeDiffView/CodeDiffView.js
@@ -1,8 +1,7 @@
-/* @flow */
-
+// TODO: finish flow annotations
 /* eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import Scroll from 'react-scroll'
 import _ from 'lodash'
 import { Row, Col, Tab, Tabs } from 'react-bootstrap'
@@ -22,7 +21,7 @@ const Element = Scroll.Element
 export type Props = {
   files: Array<any>,
   viewType?: number,
-};
+}
 
 class CodeDiffView extends Component {
   static renderValue(option) {
@@ -51,7 +50,7 @@ class CodeDiffView extends Component {
     this.renderFileDiff = this.renderFileDiff.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   onCollapseComments(collapsed) {
     // NOTE: slow operation, the whole component will be rerendered

--- a/src/components/CodeDiffView/CodeDiffView.js
+++ b/src/components/CodeDiffView/CodeDiffView.js
@@ -19,12 +19,17 @@ import './CodeDiffView.css'
 
 const Element = Scroll.Element
 
+export type Props = {
+  files: Array<any>,
+  viewType?: number,
+};
+
 class CodeDiffView extends Component {
   static renderValue(option) {
     return <span>{option.value}</span>
   }
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       viewType: props.viewType || '0',
@@ -45,6 +50,8 @@ class CodeDiffView extends Component {
     this.changeDiffViewType = this.changeDiffViewType.bind(this)
     this.renderFileDiff = this.renderFileDiff.bind(this)
   }
+
+  props: Props;
 
   onCollapseComments(collapsed) {
     // NOTE: slow operation, the whole component will be rerendered
@@ -190,11 +197,6 @@ class CodeDiffView extends Component {
       </div>
     )
   }
-}
-
-CodeDiffView.propTypes = {
-  files: PropTypes.array.isRequired,
-  viewType: PropTypes.number,
 }
 
 export default CodeDiffView

--- a/src/components/CodeDiffView/CodeDiffView.stories.js
+++ b/src/components/CodeDiffView/CodeDiffView.stories.js
@@ -1,0 +1,17 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* @flow */
+import React from 'react'
+import { storiesOf } from '@kadira/storybook'
+import { muiTheme } from 'storybook-addon-material-ui'
+
+import CodeDiffView from './CodeDiffView'
+
+import { PullRequestData } from '../../api/testPullRequest'
+
+storiesOf('CodeDiffView', module)
+  .addDecorator(muiTheme())
+  .add('compact', () => (
+    <CodeDiffView
+      files={PullRequestData}
+    />
+  ))

--- a/src/components/CodeDiffView/DiffHeader/DiffHeader.js
+++ b/src/components/CodeDiffView/DiffHeader/DiffHeader.js
@@ -1,6 +1,6 @@
-/* @flow */
+// TODO: finish flow annotations
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import IconButton from 'material-ui/IconButton'
 import View from 'material-ui/svg-icons/action/view-module'
 import { Nav, NavItem, Navbar } from 'react-bootstrap'
@@ -17,10 +17,9 @@ const navbarStyle = {
 
 export type Props = {
   title: string,
-  onViewChangeClick?: Function,
-  selectedValue?: string,
-  onCollapse?: // comments: PropTypes.bool,
-  Function,
+  onViewChangeClick: Function,
+  selectedValue: string,
+  onCollapse?: Function,
 };
 
 class DiffHeader extends Component {
@@ -37,7 +36,7 @@ class DiffHeader extends Component {
     this.handleExpandClick = this.handleExpandClick.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleChangeSingle(event, value) {
     this.setState({

--- a/src/components/CodeDiffView/DiffHeader/DiffHeader.js
+++ b/src/components/CodeDiffView/DiffHeader/DiffHeader.js
@@ -15,8 +15,16 @@ const navbarStyle = {
   fontSize: '14px',
 }
 
+export type Props = {
+  title: string,
+  onViewChangeClick?: Function,
+  selectedValue?: string,
+  onCollapse?: // comments: PropTypes.bool,
+  Function,
+};
+
 class DiffHeader extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
 
     this.state = {
@@ -28,6 +36,8 @@ class DiffHeader extends Component {
     this.handleCollapseClick = this.handleCollapseClick.bind(this)
     this.handleExpandClick = this.handleExpandClick.bind(this)
   }
+
+  props: Props;
 
   handleChangeSingle(event, value) {
     this.setState({
@@ -104,14 +114,6 @@ class DiffHeader extends Component {
       </Navbar>
     )
   }
-}
-
-DiffHeader.propTypes = {
-  title: PropTypes.string.isRequired,
-  onViewChangeClick: PropTypes.func,
-  selectedValue: PropTypes.string,
-  // comments: PropTypes.bool,
-  onCollapse: PropTypes.func,
 }
 
 

--- a/src/components/CodeDiffView/PrismCodeParser/PrismCodeParser.js
+++ b/src/components/CodeDiffView/PrismCodeParser/PrismCodeParser.js
@@ -1,5 +1,3 @@
-/* @flow */
-
 const REMOVE_MARK = '-'
 const ADDED_MARK = '+'
 

--- a/src/components/CodeDiffView/SplitRow/SplitRow.js
+++ b/src/components/CodeDiffView/SplitRow/SplitRow.js
@@ -7,8 +7,24 @@ import { NewComment, Comment } from 'components'
 import _ from 'lodash'
 import RaisedButton from 'material-ui/RaisedButton'
 
+export type Props = {
+  leftLine: string,
+  rightLine: string,
+  isBreak?: boolean,
+  leftLineNumber?: any,
+  rightLineNumber?: any,
+  leftOperation?: string,
+  rightOperation?: string,
+  leftCssClass: string,
+  rightCssClass: string,
+  leftComments?: Array<any>,
+  rightComments?: Array<any>,
+  onComment?: Function,
+  collapseComments?: boolean,
+};
+
 class SplitRow extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       leftCommentState: false,
@@ -29,6 +45,8 @@ class SplitRow extends Component {
     this.collapseRightComments = this.collapseRightComments.bind(this)
     this.handleCommentSave = this.handleCommentSave.bind(this)
   }
+
+  props: Props;
 
   componentWillReceiveProps(nextProps) {
     this.setState({
@@ -267,22 +285,6 @@ class SplitRow extends Component {
       </tr>
     )
   }
-}
-
-SplitRow.propTypes = {
-  leftLine: PropTypes.string.isRequired,
-  rightLine: PropTypes.string.isRequired,
-  isBreak: PropTypes.bool,
-  leftLineNumber: PropTypes.any,
-  rightLineNumber: PropTypes.any,
-  leftOperation: PropTypes.string,
-  rightOperation: PropTypes.string,
-  leftCssClass: PropTypes.string.isRequired,
-  rightCssClass: PropTypes.string.isRequired,
-  leftComments: PropTypes.array,
-  rightComments: PropTypes.array,
-  onComment: PropTypes.func,
-  collapseComments: PropTypes.bool,
 }
 
 export default SplitRow

--- a/src/components/CodeDiffView/SplitRow/SplitRow.js
+++ b/src/components/CodeDiffView/SplitRow/SplitRow.js
@@ -1,8 +1,7 @@
-/* @flow */
-
+// TODO: finish flow annotations
 /*eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { NewComment, Comment } from 'components'
 import _ from 'lodash'
 import RaisedButton from 'material-ui/RaisedButton'
@@ -21,7 +20,7 @@ export type Props = {
   rightComments?: Array<any>,
   onComment?: Function,
   collapseComments?: boolean,
-};
+}
 
 class SplitRow extends Component {
   constructor(props: Props) {
@@ -46,7 +45,7 @@ class SplitRow extends Component {
     this.handleCommentSave = this.handleCommentSave.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   componentWillReceiveProps(nextProps) {
     this.setState({

--- a/src/components/CodeDiffView/UnifiedRow/UnifiedRow.js
+++ b/src/components/CodeDiffView/UnifiedRow/UnifiedRow.js
@@ -1,8 +1,7 @@
-/* @flow */
-
+// TODO: add flow annotations
 /*eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { NewComment, Comment } from 'components'
 import _ from 'lodash'
 import RaisedButton from 'material-ui/RaisedButton'
@@ -34,7 +33,7 @@ class UnifiedRow extends Component {
 
   }
 
-  props: Props;
+  props: Props
 
   componentWillReceiveProps(nextProps) {
     this.setState({

--- a/src/components/CodeDiffView/UnifiedRow/UnifiedRow.js
+++ b/src/components/CodeDiffView/UnifiedRow/UnifiedRow.js
@@ -7,8 +7,20 @@ import { NewComment, Comment } from 'components'
 import _ from 'lodash'
 import RaisedButton from 'material-ui/RaisedButton'
 
+export type Props = {
+  line: string,
+  isBreak: boolean,
+  oldLineNumber: any,
+  newLineNumber: any,
+  operation: string,
+  cssClass: string,
+  comments?: Array<any>,
+  collapseComments?: boolean,
+  onComment?: Function,
+};
+
 class UnifiedRow extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       commentState: false,
@@ -21,6 +33,8 @@ class UnifiedRow extends Component {
     this.handleCommentSave = this.handleCommentSave.bind(this)
 
   }
+
+  props: Props;
 
   componentWillReceiveProps(nextProps) {
     this.setState({
@@ -133,18 +147,6 @@ class UnifiedRow extends Component {
       </tr>
     )
   }
-}
-
-UnifiedRow.propTypes = {
-  line: PropTypes.string.isRequired,
-  isBreak: PropTypes.bool.isRequired,
-  oldLineNumber: PropTypes.any.isRequired,
-  newLineNumber: PropTypes.any.isRequired,
-  operation: PropTypes.string.isRequired,
-  cssClass: PropTypes.string.isRequired,
-  comments: PropTypes.array,
-  collapseComments: PropTypes.bool,
-  onComment: PropTypes.func,
 }
 
 export default UnifiedRow

--- a/src/components/CodeDiffView/index.js
+++ b/src/components/CodeDiffView/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import CodeDiffView from './CodeDiffView'
 export default CodeDiffView

--- a/src/components/CodeMirrorView/CodeMirrorView.js
+++ b/src/components/CodeMirrorView/CodeMirrorView.js
@@ -9,7 +9,13 @@ import 'codemirror/addon/edit/matchtags'
 import 'codemirror/lib/codemirror.css'
 import './CodeMirrorView.css'
 
+export type Props = {
+  value?: string,
+  options?: Object,
+};
+
 class CodeMirrorView extends Component {
+  props: Props;
 
   componentDidMount() {
     const textarea = this.codeMirrorTextArea
@@ -39,11 +45,6 @@ class CodeMirrorView extends Component {
       />
     )
   }
-}
-
-CodeMirrorView.propTypes = {
-  value: PropTypes.string,
-  options: PropTypes.object,
 }
 
 export default CodeMirrorView

--- a/src/components/CodeMirrorView/CodeMirrorView.js
+++ b/src/components/CodeMirrorView/CodeMirrorView.js
@@ -1,6 +1,8 @@
+// TODO: add flow annotations
+
 /* eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import CodeMirror from 'codemirror'
 import 'codemirror/mode/javascript/javascript'
 import 'codemirror/addon/edit/matchbrackets'
@@ -15,7 +17,7 @@ export type Props = {
 };
 
 class CodeMirrorView extends Component {
-  props: Props;
+  props: Props
 
   componentDidMount() {
     const textarea = this.codeMirrorTextArea

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -1,6 +1,8 @@
+// TODO: finish flow annotations
+
 /* eslint-disable */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { TextEditorBox, Icon, TestAvatar } from 'components'
 import { connect } from 'react-redux'
 import IconButton from 'material-ui/IconButton'
@@ -26,7 +28,7 @@ export type Props = {
   niceToHave?: boolean,
   codeStyle?: boolean,
   hideSettings?: boolean,
-};
+}
 
 class Comment extends Component {
   constructor(props: Props) {
@@ -48,7 +50,7 @@ class Comment extends Component {
     this.handleChange = this.handleChange.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   onCommentEdit() {
     this.setState({ editMode: true })

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -12,8 +12,24 @@ import IconMenu from 'material-ui/IconMenu'
 import MenuItem from 'material-ui/MenuItem'
 import { Button, ButtonGroup } from 'react-bootstrap'
 
+export type Props = {
+  id?: string,
+  user?: string,
+  author?: string,
+  message?: any,
+  postDate?: string,
+  simpleText?: boolean,
+  style?: Object,
+  headerStyle?: Object,
+  buttonGroupStyle?: Object,
+  issue?: boolean,
+  niceToHave?: boolean,
+  codeStyle?: boolean,
+  hideSettings?: boolean,
+};
+
 class Comment extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       editMode: false,
@@ -31,6 +47,8 @@ class Comment extends Component {
     this.onCommentSave = this.onCommentSave.bind(this)
     this.handleChange = this.handleChange.bind(this)
   }
+
+  props: Props;
 
   onCommentEdit() {
     this.setState({ editMode: true })
@@ -225,22 +243,6 @@ class Comment extends Component {
       </div>
     )
   }
-}
-
-Comment.propTypes = {
-  id: PropTypes.string,
-  user: PropTypes.string,
-  author: PropTypes.string,
-  message: PropTypes.any,
-  postDate: PropTypes.string,
-  simpleText: PropTypes.bool,
-  style: PropTypes.object,
-  headerStyle: PropTypes.object,
-  buttonGroupStyle: PropTypes.object,
-  issue: PropTypes.bool,
-  niceToHave: PropTypes.bool,
-  codeStyle: PropTypes.bool,
-  hideSettings: PropTypes.bool,
 }
 
 export default Comment

--- a/src/components/CommentsList/CommentsList.js
+++ b/src/components/CommentsList/CommentsList.js
@@ -4,11 +4,15 @@ import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 import TestAvatar from '../TestAvatar'
 import './CommentsList.css'
 
+export type Props = { comments?: any };
+
 class CommentsList extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { search: null }
   }
+
+  props: Props;
 
   render() {
     return (
@@ -68,10 +72,6 @@ class CommentsList extends Component {
       </div>
     )
   }
-}
-
-CommentsList.propTypes = {
-  comments: PropTypes.any,
 }
 
 export default CommentsList

--- a/src/components/CommentsList/CommentsList.js
+++ b/src/components/CommentsList/CommentsList.js
@@ -1,4 +1,6 @@
-import React, { PropTypes, Component } from 'react'
+// TODO: add flow annotations
+
+import React, { Component } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 
 import TestAvatar from '../TestAvatar'
@@ -12,7 +14,7 @@ class CommentsList extends Component {
     this.state = { search: null }
   }
 
-  props: Props;
+  props: Props
 
   render() {
     return (

--- a/src/components/CommentsList/CommentsList.js
+++ b/src/components/CommentsList/CommentsList.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, Component } from 'react'
-import { TestAvatar } from 'components'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
+
+import TestAvatar from '../TestAvatar'
 import './CommentsList.css'
 
 class CommentsList extends Component {

--- a/src/components/CommentsList/index.js
+++ b/src/components/CommentsList/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import CommentsList from './CommentsList'
 export default CommentsList

--- a/src/components/Divider/Divider.js
+++ b/src/components/Divider/Divider.js
@@ -1,3 +1,4 @@
+export type Props = { text?: number | string | React.Element | Array<any> };
 import React, { PropTypes } from 'react'
 import './Divider.css'
 
@@ -9,10 +10,6 @@ function Divider(props) {
       </span>
     </div>
   )
-}
-
-Divider.propTypes = {
-  text: PropTypes.node.isRequired,
 }
 
 export default Divider

--- a/src/components/Divider/Divider.js
+++ b/src/components/Divider/Divider.js
@@ -1,12 +1,15 @@
-export type Props = { text?: number | string | React.Element | Array<any> };
-import React, { PropTypes } from 'react'
+/* @flow */
+
+import React from 'react'
 import './Divider.css'
 
-function Divider(props) {
+export type Props = { text: number | string };
+
+function Divider({ text }: Props) {
   return (
     <div className="divider">
       <span className="divider-text">
-        {props.text}
+        {text}
       </span>
     </div>
   )

--- a/src/components/Divider/index.js
+++ b/src/components/Divider/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+import Divider from './Divider'
+export default Divider

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -9,11 +9,13 @@ const styles = {
 }
 
 export default class SelectFieldExampleSimple extends React.Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { value: 1 }
     this.handleChange = this.handleChange.bind(this)
   }
+
+  props: Props;
 
   handleChange(event, index, value) { return this.setState({ value }) }
 

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -1,3 +1,5 @@
+// TODO: add flow annotations
+
 import React from 'react'
 import SelectField from 'material-ui/SelectField'
 import MenuItem from 'material-ui/MenuItem'
@@ -9,13 +11,11 @@ const styles = {
 }
 
 export default class SelectFieldExampleSimple extends React.Component {
-  constructor(props: Props) {
+  constructor(props) {
     super(props)
     this.state = { value: 1 }
     this.handleChange = this.handleChange.bind(this)
   }
-
-  props: Props;
 
   handleChange(event, index, value) { return this.setState({ value }) }
 

--- a/src/components/ErrorMessage/index.js
+++ b/src/components/ErrorMessage/index.js
@@ -1,3 +1,4 @@
+export type Props = { error?: string };
 import React, { PropTypes } from 'react'
 import Paper from 'material-ui/Paper'
 import ErrorIcon from 'material-ui/svg-icons/alert/error'
@@ -14,10 +15,6 @@ function ErrorMessage({ error }) {
       </div>
     </Paper>
   )
-}
-
-ErrorMessage.propTypes = {
-  error: PropTypes.string.isRequired,
 }
 
 export default ErrorMessage

--- a/src/components/ErrorMessage/index.js
+++ b/src/components/ErrorMessage/index.js
@@ -1,10 +1,13 @@
-export type Props = { error?: string };
-import React, { PropTypes } from 'react'
+/* @flow */
+
+import React from 'react'
 import Paper from 'material-ui/Paper'
 import ErrorIcon from 'material-ui/svg-icons/alert/error'
 import { red500 } from 'material-ui/styles/colors'
 
-function ErrorMessage({ error }) {
+export type Props = { error: string };
+
+function ErrorMessage({ error }: Props) {
   return (
     <Paper style={{ padding: '20px' }}>
       <div style={{ float: 'left' }}>

--- a/src/components/Expander/Expander.js
+++ b/src/components/Expander/Expander.js
@@ -1,18 +1,15 @@
+// TODO: add flow annotations
 /* eslint-disable */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import './Expander.css'
 
-export type Props = { children: number | string | React.Element | Array<any> };
-
 class Expander extends Component {
-  constructor(props: Props) {
+  constructor(props) {
     super(props)
     this.state = { collapsed: true }
     this.expandHandler = this.expandHandler.bind(this)
   }
-
-  props: Props;
 
   expandHandler() {
     const state = this.state.collapsed

--- a/src/components/Expander/Expander.js
+++ b/src/components/Expander/Expander.js
@@ -3,12 +3,16 @@
 import React, { Component, PropTypes } from 'react'
 import './Expander.css'
 
+export type Props = { children: number | string | React.Element | Array<any> };
+
 class Expander extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { collapsed: true }
     this.expandHandler = this.expandHandler.bind(this)
   }
+
+  props: Props;
 
   expandHandler() {
     const state = this.state.collapsed
@@ -27,10 +31,6 @@ class Expander extends Component {
       </div>
     )
   }
-}
-
-Expander.propTypes = {
-  children: PropTypes.node.isRequired,
 }
 
 export default Expander

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -1,3 +1,8 @@
+export type Props = {
+  data?: Array<any>,
+  onFileClick?: Function,
+};
+
 /* eslint-disable */
 
 import React, { PropTypes } from 'react'
@@ -67,9 +72,6 @@ const FileList = ({ data, onFileClick }) =>
     </TableBody>
   </Table>
 
-FileList.propTypes = {
-  data: PropTypes.array.isRequired,
-  onFileClick: PropTypes.func.isRequired,
-}
+;
 
 export default FileList

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -1,11 +1,7 @@
-export type Props = {
-  data?: Array<any>,
-  onFileClick?: Function,
-};
-
+/* @flow */
 /* eslint-disable */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { Link } from 'react-router'
 import _ from 'lodash'
 import {
@@ -19,7 +15,12 @@ import {
 import FolderClosedIcon from 'material-ui/svg-icons/file/folder'
 import File from 'material-ui/svg-icons/editor/insert-drive-file'
 
-const FileList = ({ data, onFileClick }) =>
+export type Props = {
+  data: Array<any>,
+  onFileClick: Function,
+};
+
+const FileList = ({ data, onFileClick }: Props) =>
   <Table height={'500px'}>
     <TableHeader
       adjustForCheckbox={false}

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -14,8 +14,8 @@ import {
 import FolderClosedIcon from 'material-ui/svg-icons/file/folder'
 import File from 'material-ui/svg-icons/editor/insert-drive-file'
 
-function FileList({ data, onFileClick }) {
-  return (<Table height={'500px'}>
+const FileList = ({ data, onFileClick }) =>
+  <Table height={'500px'}>
     <TableHeader
       adjustForCheckbox={false}
       enableSelectAll={false}
@@ -65,8 +65,7 @@ function FileList({ data, onFileClick }) {
         </TableRow>
       ))}
     </TableBody>
-  </Table>)
-}
+  </Table>
 
 FileList.propTypes = {
   data: PropTypes.array.isRequired,

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -1,26 +1,29 @@
+/* @flow */
+
 import Select from 'react-select'
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import 'react-select/dist/react-select.css'
 
 export type Props = {
-  placeholder?: // project: PropTypes.string.isRequired,
-  // defaultValue: PropTypes.string,
-  string,
-  data: // style: PropTypes.object,
-  Array<any>,
+  placeholder?: string,
+  data: Array<any>,
   onChange?: Function,
 };
 
 class Filter extends Component {
   constructor(props: Props) {
     super(props)
-    this.state = { value: null }
-    this.handleChange = this.handleChange.bind(this)
+    this.state = { value: null };
+    (this:any).handleChange = this.handleChange.bind(this)
   }
 
-  props: Props;
+  state: {
+    value: ?string,
+  };
 
-  handleChange(r) {
+  props: Props
+
+  handleChange(r: string) {
     this.setState({
       value: r,
     })

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -2,12 +2,23 @@ import Select from 'react-select'
 import React, { Component, PropTypes } from 'react'
 import 'react-select/dist/react-select.css'
 
+export type Props = {
+  placeholder?: // project: PropTypes.string.isRequired,
+  // defaultValue: PropTypes.string,
+  string,
+  data: // style: PropTypes.object,
+  Array<any>,
+  onChange?: Function,
+};
+
 class Filter extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { value: null }
     this.handleChange = this.handleChange.bind(this)
   }
+
+  props: Props;
 
   handleChange(r) {
     this.setState({
@@ -31,15 +42,6 @@ class Filter extends Component {
       </div>
     )
   }
-}
-
-Filter.propTypes = {
-  // project: PropTypes.string.isRequired,
-  // defaultValue: PropTypes.string,
-  placeholder: PropTypes.string,
-  // style: PropTypes.object,
-  data: PropTypes.array.isRequired,
-  onChange: PropTypes.func,
 }
 
 export default Filter

--- a/src/components/Filter/index.js
+++ b/src/components/Filter/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+import Filter from './Filter'
+export default Filter

--- a/src/components/FollowedProjectsList/FollowedProjectsList.js
+++ b/src/components/FollowedProjectsList/FollowedProjectsList.js
@@ -1,3 +1,4 @@
+export type Props = {};
 /* eslint-disable max-len */
 
 import React from 'react'
@@ -66,10 +67,6 @@ function FollowedProjectsList() {
 
     </List>
   )
-}
-
-FollowedProjectsList.propTypes = {
-  // data: PropTypes.array,
 }
 
 export default FollowedProjectsList

--- a/src/components/FollowedProjectsList/FollowedProjectsList.js
+++ b/src/components/FollowedProjectsList/FollowedProjectsList.js
@@ -1,4 +1,3 @@
-export type Props = {};
 /* eslint-disable max-len */
 
 import React from 'react'

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,17 +1,13 @@
-export type Props = {
-  title?: string,
-  showMenuIconButton?: boolean,
-  dispatch?: Function,
-  projectName?: string,
-};
+/* @flow */
 
-import React, { PropTypes } from 'react'
-import { Logout, SearchBox } from 'components'
+import React from 'react'
 import { routes } from 'universal/constants'
 import { connect } from 'react-redux'
 import { Navbar, Nav } from 'react-bootstrap'
 import Badge from 'material-ui/Badge'
 
+import Logout from '../Logout'
+import SearchBox from '../SearchBox'
 import './styles.css'
 
 const badgeStyle = {
@@ -21,7 +17,14 @@ const badgeStyle = {
   color: '#878a9f',
 }
 
-function Header() {
+export type Props = {
+  title?: string,
+  showMenuIconButton?: boolean,
+  dispatch?: Function,
+  projectName?: string,
+}
+
+function Header(props: Props) {
   return (
     <div>
       <Navbar

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,3 +1,10 @@
+export type Props = {
+  title?: string,
+  showMenuIconButton?: boolean,
+  dispatch?: Function,
+  projectName?: string,
+};
+
 import React, { PropTypes } from 'react'
 import { Logout, SearchBox } from 'components'
 import { routes } from 'universal/constants'
@@ -56,13 +63,6 @@ function Header() {
       </Navbar>
     </div>
   )
-}
-
-Header.propTypes = {
-  title: PropTypes.string.isRequired,
-  showMenuIconButton: PropTypes.bool.isRequired,
-  dispatch: PropTypes.func,
-  projectName: PropTypes.string,
 }
 
 export default connect(state => ({

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,17 +1,18 @@
+/* @flow */
+/* eslint-disable */
+
+import React from 'react'
+import Avatar from 'material-ui/Avatar'
+
 export type Props = {
-  icon?: number | string | React.Element | Array<any>,
+  icon?: number | string | React.Element<any> | Array<any>,
   size?: number,
   color?: string,
   backgroundColor?: string,
   style?: Object,
 };
 
-/* eslint-disable */
-
-import React, { PropTypes } from 'react'
-import Avatar from 'material-ui/Avatar'
-
-function Icon(props) {
+function Icon(props: Props) {
   const { icon, size, color, backgroundColor, style } = props
   const defaultStyle = { borderRadius: 0 }
   return (

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,3 +1,11 @@
+export type Props = {
+  icon?: number | string | React.Element | Array<any>,
+  size?: number,
+  color?: string,
+  backgroundColor?: string,
+  style?: Object,
+};
+
 /* eslint-disable */
 
 import React, { PropTypes } from 'react'
@@ -15,14 +23,6 @@ function Icon(props) {
       style={style || defaultStyle}
     />
   )
-}
-
-Icon.propTypes = {
-  icon: PropTypes.node.isRequired,
-  size: PropTypes.number,
-  color: PropTypes.string,
-  backgroundColor: PropTypes.string,
-  style: PropTypes.object,
 }
 
 export default Icon

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import Icon from './Icon'
 export default Icon

--- a/src/components/IssuesList/IssuesList.js
+++ b/src/components/IssuesList/IssuesList.js
@@ -1,8 +1,11 @@
+/* @flow */
+
 /* eslint-disable */
-import React, { PropTypes, Component } from 'react'
-import { TestAvatar } from 'components'
+import React, { Component } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 import _ from 'lodash'
+
+import TestAvatar from '../TestAvatar'
 import './IssuesList.css'
 
 
@@ -14,7 +17,7 @@ const subHeader = text => (
   </div>
 )
 
-export type Props = { issues?: any };
+export type Props = { issues: any };
 
 class IssuesList extends Component {
   constructor(props: Props) {
@@ -22,7 +25,11 @@ class IssuesList extends Component {
     this.state = { search: null }
   }
 
-  props: Props;
+  state: {
+    search: ?string,
+  };
+
+  props: Props
 
   render() {
     const greenStatus = { borderLeft: '4px solid #d1fad1' }

--- a/src/components/IssuesList/IssuesList.js
+++ b/src/components/IssuesList/IssuesList.js
@@ -14,11 +14,15 @@ const subHeader = text => (
   </div>
 )
 
+export type Props = { issues?: any };
+
 class IssuesList extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { search: null }
   }
+
+  props: Props;
 
   render() {
     const greenStatus = { borderLeft: '4px solid #d1fad1' }
@@ -100,10 +104,6 @@ class IssuesList extends Component {
       </div>
     )
   }
-}
-
-IssuesList.propTypes = {
-  issues: PropTypes.any,
 }
 
 export default IssuesList

--- a/src/components/KafkaBadge/KafkaBadge.js
+++ b/src/components/KafkaBadge/KafkaBadge.js
@@ -1,3 +1,9 @@
+export type Props = {
+  count?: number,
+  isAuthenticated?: boolean,
+  messages?: Array<any>,
+};
+
 /* eslint-disable import/no-extraneous-dependencies */
 
 import React, { PropTypes } from 'react'
@@ -41,12 +47,6 @@ function KafkaBadge({ count, isAuthenticated, messages }) {
     }
     </div>
   )
-}
-
-KafkaBadge.propTypes = {
-  count: PropTypes.number.isRequired,
-  isAuthenticated: PropTypes.bool.isRequired,
-  messages: PropTypes.array.isRequired,
 }
 
 export default connect(state => ({

--- a/src/components/KafkaBadge/KafkaBadge.js
+++ b/src/components/KafkaBadge/KafkaBadge.js
@@ -1,4 +1,4 @@
-// TODO: add flow annotations
+/* @flow */
 /* eslint-disable import/no-extraneous-dependencies */
 
 import React from 'react'
@@ -10,7 +10,6 @@ import Badge from 'material-ui/Badge'
 import NotificationsIcon from 'material-ui/svg-icons/social/notifications'
 import NotificationsIconNone from 'material-ui/svg-icons/social/notifications-none'
 import { connect } from 'react-redux'
-import { selectors } from 'ducks/auth'  // FIXME: not existing...
 
 export type Props = {
   count: number,
@@ -53,7 +52,7 @@ function KafkaBadge({ count, isAuthenticated, messages }: Props) {
 }
 
 export default connect(state => ({
-  isAuthenticated: selectors.isAuthenticated(state),
+  isAuthenticated: true,  // FIXME
   count: state.kafka.count || 0,
   messages: state.kafka.messages || [],
 }))(KafkaBadge)

--- a/src/components/KafkaBadge/KafkaBadge.js
+++ b/src/components/KafkaBadge/KafkaBadge.js
@@ -1,12 +1,7 @@
-export type Props = {
-  count?: number,
-  isAuthenticated?: boolean,
-  messages?: Array<any>,
-};
-
+// TODO: add flow annotations
 /* eslint-disable import/no-extraneous-dependencies */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import IconButton from 'material-ui/IconButton'
 import IconMenu from 'material-ui/IconMenu'
 import MenuItem from 'material-ui/MenuItem'
@@ -15,9 +10,17 @@ import Badge from 'material-ui/Badge'
 import NotificationsIcon from 'material-ui/svg-icons/social/notifications'
 import NotificationsIconNone from 'material-ui/svg-icons/social/notifications-none'
 import { connect } from 'react-redux'
-import { selectors } from 'ducks/auth'
+import { selectors } from 'ducks/auth'  // FIXME: not existing...
 
-function KafkaBadge({ count, isAuthenticated, messages }) {
+export type Props = {
+  count: number,
+  isAuthenticated: boolean,
+  messages: Array<{
+    message: string,
+  }>,
+};
+
+function KafkaBadge({ count, isAuthenticated, messages }: Props) {
   return (
     <div>
     {isAuthenticated && count > 0 &&

--- a/src/components/Label/Label.js
+++ b/src/components/Label/Label.js
@@ -1,12 +1,14 @@
+/* @flow */
+
+import React from 'react'
+
 export type Props = {
-  text?: string,
+  text: string,
   prefix?: string,
   color?: string,
-};
+}
 
-import React, { PropTypes } from 'react'
-
-function Label(props) {
+function Label(props: Props) {
   const { text, color, prefix } = props
   const style = {
     backgroundColor: color || '#ffffff',

--- a/src/components/Label/Label.js
+++ b/src/components/Label/Label.js
@@ -1,3 +1,9 @@
+export type Props = {
+  text?: string,
+  prefix?: string,
+  color?: string,
+};
+
 import React, { PropTypes } from 'react'
 
 function Label(props) {
@@ -17,12 +23,6 @@ function Label(props) {
       <strong>{text}</strong>
     </span>
   )
-}
-
-Label.propTypes = {
-  text: PropTypes.string.isRequired,
-  prefix: PropTypes.string.isRequired,
-  color: PropTypes.string,
 }
 
 export default Label

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,13 +1,15 @@
+/* @flow */
+
+import React from 'react'
+import { Link as RouterLink } from 'react-router'
+
 export type Props = {
   style?: Object,
   label?: string,
   to?: string,
 };
 
-import React, { PropTypes } from 'react'
-import { Link as RouterLink } from 'react-router'
-
-function Link(props) {
+function Link(props: Props) {
   const defaultStyle = {
     fontSize: '14px',
     color: 'rgb(92, 92, 92)',

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,3 +1,9 @@
+export type Props = {
+  style?: Object,
+  label?: string,
+  to?: string,
+};
+
 import React, { PropTypes } from 'react'
 import { Link as RouterLink } from 'react-router'
 
@@ -13,12 +19,6 @@ function Link(props) {
   return (
     <RouterLink style={style || defaultStyle} to={to}>{label}</RouterLink>
   )
-}
-
-Link.propTypes = {
-  style: PropTypes.object,
-  label: PropTypes.string.isRequired,
-  to: PropTypes.string.isRequired,
 }
 
 export default Link

--- a/src/components/LinkButton/LinkButton.js
+++ b/src/components/LinkButton/LinkButton.js
@@ -1,3 +1,9 @@
+export type Props = {
+  style?: Object,
+  label?: string,
+  to?: string,
+};
+
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
 import RaisedButton from 'material-ui/RaisedButton'
@@ -13,12 +19,6 @@ function LinkButton(props) {
       />
     </Link>
   )
-}
-
-LinkButton.propTypes = {
-  style: PropTypes.object,
-  label: PropTypes.string.isRequired,
-  to: PropTypes.string.isRequired,
 }
 
 export default LinkButton

--- a/src/components/LinkButton/LinkButton.js
+++ b/src/components/LinkButton/LinkButton.js
@@ -1,14 +1,16 @@
-export type Props = {
-  style?: Object,
-  label?: string,
-  to?: string,
-};
+/* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { Link } from 'react-router'
 import RaisedButton from 'material-ui/RaisedButton'
 
-function LinkButton(props) {
+export type Props = {
+  style?: Object,
+  label: string,
+  to: string,
+};
+
+function LinkButton(props: Props) {
   const { style, to, label } = props
   return (
     <Link to={to}>

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -2,12 +2,21 @@ import React, { Component, PropTypes } from 'react'
 import { ListGroup, Pagination } from 'react-bootstrap'
 import './styles.css'
 
+export type Props = {
+  activePage?: number,
+  totalPagesCount?: number,
+  onPageSelect?: Function,
+  children: any,
+};
+
 class List extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { activePage: this.props.activePage }
     this.handleSelect = this.handleSelect.bind(this)
   }
+
+  props: Props;
 
   handleSelect(eventKey) {
     this.setState({
@@ -48,13 +57,6 @@ class List extends Component {
       </div>
     )
   }
-}
-
-List.propTypes = {
-  activePage: PropTypes.number,
-  totalPagesCount: PropTypes.number,
-  onPageSelect: PropTypes.func,
-  children: PropTypes.any.isRequired,
 }
 
 export default List

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,24 +1,17 @@
-import React, { Component, PropTypes } from 'react'
+// TODO: add flow annotations
+
+import React, { Component } from 'react'
 import { ListGroup, Pagination } from 'react-bootstrap'
 import './styles.css'
 
-export type Props = {
-  activePage?: number,
-  totalPagesCount?: number,
-  onPageSelect?: Function,
-  children: any,
-};
-
 class List extends Component {
-  constructor(props: Props) {
+  constructor(props) {
     super(props)
     this.state = { activePage: this.props.activePage }
     this.handleSelect = this.handleSelect.bind(this)
   }
 
-  props: Props;
-
-  handleSelect(eventKey) {
+  handleSelect(eventKey: number) {
     this.setState({
       activePage: eventKey,
     })

--- a/src/components/LoginForm/index.js
+++ b/src/components/LoginForm/index.js
@@ -1,3 +1,10 @@
+export type Props = {
+  isSendingRequest?: boolean,
+  onSubmitClick?: Function,
+  //fields: PropTypes.object,
+  error?: string,
+};
+
 import React, { PropTypes } from 'react'
 import { reduxForm, Field } from 'redux-form'
 import RaisedButton from 'material-ui/RaisedButton'
@@ -35,11 +42,7 @@ const renderTextField = ({ input, label, meta: { touched, error }, ...custom }) 
   />
 )
 
-renderTextField.propTypes = {
-  input: PropTypes.bool,
-  label: PropTypes.func,
-  meta: PropTypes.object,
-}
+;
 
 function LoginForm(props) {
   const { isSendingRequest, error, onSubmitClick } = props
@@ -73,13 +76,6 @@ function LoginForm(props) {
       }
     </form>
   )
-}
-
-LoginForm.propTypes = {
-  isSendingRequest: PropTypes.bool,
-  onSubmitClick: PropTypes.func,
-  error: PropTypes.string,
-  //fields: PropTypes.object,
 }
 
 export default reduxForm({

--- a/src/components/LoginForm/index.js
+++ b/src/components/LoginForm/index.js
@@ -1,18 +1,12 @@
-export type Props = {
-  isSendingRequest?: boolean,
-  onSubmitClick?: Function,
-  //fields: PropTypes.object,
-  error?: string,
-};
+// TODO: add flow annotations
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { reduxForm, Field } from 'redux-form'
 import RaisedButton from 'material-ui/RaisedButton'
 import TextField from 'material-ui/TextField'
 import ErrorMessage from 'components/ErrorMessage'
 import LoadingIcon from 'components/LoadingIcon'
 import './styles.css'
-
 
 const validate = (values) => {
   const errors = {}
@@ -29,7 +23,6 @@ const validate = (values) => {
   return errors
 }
 
-
 const renderTextField = ({ input, label, meta: { touched, error }, ...custom }) => (
   <TextField
     hintText={label}
@@ -42,9 +35,14 @@ const renderTextField = ({ input, label, meta: { touched, error }, ...custom }) 
   />
 )
 
-;
+export type Props = {
+  isSendingRequest: boolean,
+  onSubmitClick: Function,
+  // fields: PropTypes.object,
+  error?: string,
+}
 
-function LoginForm(props) {
+function LoginForm(props: Props) {
   const { isSendingRequest, error, onSubmitClick } = props
   const handleSubmit = (event) => {
     event.preventDefault()

--- a/src/components/Logout/index.js
+++ b/src/components/Logout/index.js
@@ -1,26 +1,32 @@
-export type Props = {
-  persona?: string,
-  username?: string,
-  logoutRoute?: string,
-};
+/* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import MenuItem from 'material-ui/MenuItem'
 import IconMenu from 'material-ui/IconMenu'
 import Divider from 'material-ui/Divider'
 import IconButton from 'material-ui/IconButton'
-import { TestAvatar } from 'components'
+
+import TestAvatar from '../TestAvatar'
 
 import {
   GUARDIAN_PERSONA,
   DEVELOPER_PERSONA,
   MANAGER_PERSONA,
-  changePersona,
 } from 'ducks/session'
 import More from 'material-ui/svg-icons/navigation/more-vert'
 
-function Logout(props) {
+export type Props = {
+  persona: string,
+  username: string,
+  logoutRoute: string,
+};
+
+const changePersona = () => {
+  // FIXME
+}
+
+function Logout(props: Props) {
   const { username, persona, logoutRoute } = props
   return (
     <div>
@@ -88,5 +94,5 @@ export default connect(
   state => ({
     persona: state.session.persona,
     username: state.session.profile.username || '',
-  }), { changePersona }
+  })
 )(Logout)

--- a/src/components/Logout/index.js
+++ b/src/components/Logout/index.js
@@ -1,3 +1,9 @@
+export type Props = {
+  persona?: string,
+  username?: string,
+  logoutRoute?: string,
+};
+
 import React, { PropTypes } from 'react'
 import { connect } from 'react-redux'
 import MenuItem from 'material-ui/MenuItem'
@@ -76,12 +82,6 @@ function Logout(props) {
       </IconMenu>
     </div>
   )
-}
-
-Logout.propTypes = {
-  persona: PropTypes.string.isRequired,
-  username: PropTypes.string.isRequired,
-  logoutRoute: PropTypes.string.isRequired,
 }
 
 export default connect(

--- a/src/components/MessageBadge/MessageBadge.js
+++ b/src/components/MessageBadge/MessageBadge.js
@@ -1,20 +1,19 @@
-export type Props = {
-  count?: number,
-  //messages: PropTypes.array.isRequired,
-  isAuthenticated?: boolean,
-};
-
+// TODO: add flow annotations
 /* eslint-disable import/no-extraneous-dependencies */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import IconButton from 'material-ui/IconButton'
 import Badge from 'material-ui/Badge'
 import Message from 'material-ui/svg-icons/communication/message'
 import { connect } from 'react-redux'
-import { selectors } from 'ducks/auth'
+import { selectors } from 'ducks/auth'  // FIXME: not existing...
 
+export type Props = {
+  count: number,
+  isAuthenticated: boolean,
+}
 
-function MessageBadge({ count, isAuthenticated }) {
+function MessageBadge({ count, isAuthenticated }: Props) {
   return (
     <div> {
       isAuthenticated &&

--- a/src/components/MessageBadge/MessageBadge.js
+++ b/src/components/MessageBadge/MessageBadge.js
@@ -1,4 +1,4 @@
-// TODO: add flow annotations
+/* @flow */
 /* eslint-disable import/no-extraneous-dependencies */
 
 import React from 'react'
@@ -6,7 +6,6 @@ import IconButton from 'material-ui/IconButton'
 import Badge from 'material-ui/Badge'
 import Message from 'material-ui/svg-icons/communication/message'
 import { connect } from 'react-redux'
-import { selectors } from 'ducks/auth'  // FIXME: not existing...
 
 export type Props = {
   count: number,
@@ -31,7 +30,7 @@ function MessageBadge({ count, isAuthenticated }: Props) {
 }
 
 export default connect(state => ({
-  isAuthenticated: selectors.isAuthenticated(state),
+  isAuthenticated: true,  // FIXME
   count: state.chat.count || 0,
   messages: [],
 }))(MessageBadge)

--- a/src/components/MessageBadge/MessageBadge.js
+++ b/src/components/MessageBadge/MessageBadge.js
@@ -1,3 +1,9 @@
+export type Props = {
+  count?: number,
+  //messages: PropTypes.array.isRequired,
+  isAuthenticated?: boolean,
+};
+
 /* eslint-disable import/no-extraneous-dependencies */
 
 import React, { PropTypes } from 'react'
@@ -23,12 +29,6 @@ function MessageBadge({ count, isAuthenticated }) {
           </IconButton>
         </Badge>}
     </div>)
-}
-
-MessageBadge.propTypes = {
-  count: PropTypes.number.isRequired,
-  isAuthenticated: PropTypes.bool.isRequired,
-  //messages: PropTypes.array.isRequired,
 }
 
 export default connect(state => ({

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,3 +1,10 @@
+export type Props = {
+  // title: PropTypes.string.isRequired,
+  showMenuIconButton?: boolean,
+  appBarStyle?: Object,
+  dispatch?: Function,
+};
+
 import React, { PropTypes } from 'react'
 import AppBar from 'material-ui/AppBar'
 import Open from 'material-ui/svg-icons/navigation/menu'
@@ -47,13 +54,6 @@ function NavBar({ appBarStyle, showMenuIconButton, dispatch }) {
       <KafkaBadge />
       <Logout />
     </AppBar>)
-}
-
-NavBar.propTypes = {
-  // title: PropTypes.string.isRequired,
-  showMenuIconButton: PropTypes.bool.isRequired,
-  appBarStyle: PropTypes.object,
-  dispatch: PropTypes.func,
 }
 
 export default connect(state => ({

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,21 +1,25 @@
-export type Props = {
-  // title: PropTypes.string.isRequired,
-  showMenuIconButton?: boolean,
-  appBarStyle?: Object,
-  dispatch?: Function,
-};
+/* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import AppBar from 'material-ui/AppBar'
 import Open from 'material-ui/svg-icons/navigation/menu'
 import TextField from 'material-ui/TextField'
 import Search from 'material-ui/svg-icons/action/search'
-import { KafkaBadge, MessageBadge, Logout } from 'components'
 import IconButton from 'material-ui/IconButton'
 import { connect } from 'react-redux'
+
+import KafkaBadge from '../KafkaBadge/KafkaBadge'
+import MessageBadge from '../MessageBadge/MessageBadge'
+import Logout from '../Logout'
 import { OPEN_SIDE_BAR } from 'ducks/sidebar'
 
-function NavBar({ appBarStyle, showMenuIconButton, dispatch }) {
+export type Props = {
+  showMenuIconButton: boolean,
+  appBarStyle?: Object,
+  dispatch: Function,
+}
+
+function NavBar({ appBarStyle, showMenuIconButton, dispatch }: Props) {
   const searchStyle = {
     width: '40px',
     margin: '0 10px',

--- a/src/components/NewComment/NewComment.js
+++ b/src/components/NewComment/NewComment.js
@@ -1,4 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+// TODO: add flow annotations
+
+import React, { Component } from 'react'
 import RaisedButton from 'material-ui/RaisedButton'
 
 import TextEditorBox from '../TextEditorBox'
@@ -8,7 +10,7 @@ export type Props = {
   onComment?: Function,
   style?: Object,
   headerStyle?: Object,
-};
+}
 
 class NewComment extends Component {
   constructor(props: Props) {
@@ -20,7 +22,7 @@ class NewComment extends Component {
     this.handleCommentSave = this.handleCommentSave.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleCommentCancel() {
     this.setState({ commentText: '' })

--- a/src/components/NewComment/NewComment.js
+++ b/src/components/NewComment/NewComment.js
@@ -3,8 +3,15 @@ import RaisedButton from 'material-ui/RaisedButton'
 
 import TextEditorBox from '../TextEditorBox'
 
+export type Props = {
+  onCancel?: Function,
+  onComment?: Function,
+  style?: Object,
+  headerStyle?: Object,
+};
+
 class NewComment extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       commentText: '',
@@ -12,6 +19,8 @@ class NewComment extends Component {
     this.handleCommentCancel = this.handleCommentCancel.bind(this)
     this.handleCommentSave = this.handleCommentSave.bind(this)
   }
+
+  props: Props;
 
   handleCommentCancel() {
     this.setState({ commentText: '' })
@@ -61,13 +70,6 @@ class NewComment extends Component {
       </div>
     )
   }
-}
-
-NewComment.propTypes = {
-  onCancel: PropTypes.func,
-  onComment: PropTypes.func,
-  style: PropTypes.object,
-  headerStyle: PropTypes.object,
 }
 
 export default NewComment

--- a/src/components/NotificationList/PullRequestComment/PullRequestComment.js
+++ b/src/components/NotificationList/PullRequestComment/PullRequestComment.js
@@ -1,3 +1,10 @@
+export type Props = {
+  title?: string,
+  author?: string,
+  primaryTextStyle?: string,
+  secondaryTextStyle?: string,
+};
+
 import React, { PropTypes } from 'react'
 import { ListItem } from 'material-ui/List'
 import { Link } from 'react-router'
@@ -37,13 +44,6 @@ function PullRequestComment(props) {
       secondaryTextLines={2}
     />
   )
-}
-
-PullRequestComment.propTypes = {
-  title: PropTypes.string,
-  author: PropTypes.string,
-  primaryTextStyle: PropTypes.string,
-  secondaryTextStyle: PropTypes.string,
 }
 
 export default PullRequestComment

--- a/src/components/NotificationList/PullRequestComment/PullRequestComment.js
+++ b/src/components/NotificationList/PullRequestComment/PullRequestComment.js
@@ -1,17 +1,20 @@
+/* @flow */
+
+import React from 'react'
+import { ListItem } from 'material-ui/List'
+import { Link } from 'react-router'
+import { darkBlack } from 'material-ui/styles/colors'
+
+import TestAvatar from '../../TestAvatar'
+
 export type Props = {
   title?: string,
   author?: string,
   primaryTextStyle?: string,
   secondaryTextStyle?: string,
-};
+}
 
-import React, { PropTypes } from 'react'
-import { ListItem } from 'material-ui/List'
-import { Link } from 'react-router'
-import { darkBlack } from 'material-ui/styles/colors'
-import { TestAvatar } from 'components'
-
-function PullRequestComment(props) {
+function PullRequestComment(props: Props) {
   return (
     <ListItem
       leftAvatar={

--- a/src/components/ProjectList/ProjectItem.js
+++ b/src/components/ProjectList/ProjectItem.js
@@ -1,6 +1,7 @@
+// TODO: add flow annotations
 /* eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import _ from 'lodash'
 import Col from 'react-bootstrap/lib/Col'
 import Row from 'react-bootstrap/lib/Row'
@@ -25,7 +26,7 @@ export type Props = {
   // owner: PropTypes.string,
   number,
   valueProp: string,
-};
+}
 
 class ProjectItem extends Component {
   constructor(props: Props) {
@@ -39,7 +40,7 @@ class ProjectItem extends Component {
     this.toggleFollow = this.toggleFollow.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   toggleOpen() {
     const value = this.state.open

--- a/src/components/ProjectList/ProjectItem.js
+++ b/src/components/ProjectList/ProjectItem.js
@@ -15,8 +15,20 @@ const subHeader = text => (
   </div>
 )
 
+export type Props = {
+  item: Object,
+  clickHandler: Function,
+  childrenProp: string,
+  primaryTextProp: string,
+  secondaryTextProp?: string,
+  inset?: // updated: PropTypes.string,
+  // owner: PropTypes.string,
+  number,
+  valueProp: string,
+};
+
 class ProjectItem extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
 
     this.state = {
@@ -26,6 +38,8 @@ class ProjectItem extends Component {
     this.toggleOpen = this.toggleOpen.bind(this)
     this.toggleFollow = this.toggleFollow.bind(this)
   }
+
+  props: Props;
 
   toggleOpen() {
     const value = this.state.open
@@ -136,18 +150,6 @@ class ProjectItem extends Component {
         <Divider />
       </div>)
   }
-}
-
-ProjectItem.propTypes = {
-  item: PropTypes.object.isRequired,
-  clickHandler: PropTypes.func.isRequired,
-  childrenProp: PropTypes.string.isRequired,
-  primaryTextProp: PropTypes.string.isRequired,
-  secondaryTextProp: PropTypes.string,
-  // updated: PropTypes.string,
-  // owner: PropTypes.string,
-  inset: PropTypes.number,
-  valueProp: PropTypes.string.isRequired,
 }
 
 export default ProjectItem

--- a/src/components/ProjectList/ProjectList.js
+++ b/src/components/ProjectList/ProjectList.js
@@ -1,10 +1,15 @@
-export type Props = { data?: Array<any> };
-import React, { PropTypes } from 'react'
+/* @flow */
+
+import React from 'react'
 import _ from 'lodash'
 import { List } from 'material-ui/List'
 import ProjectItem from './ProjectItem'
 
-function ProjectList(props) {
+export type Props = {
+  data?: Array<any>
+}
+
+function ProjectList(props: Props) {
   const { data } = props
   return (
     <List

--- a/src/components/ProjectList/ProjectList.js
+++ b/src/components/ProjectList/ProjectList.js
@@ -1,3 +1,4 @@
+export type Props = { data?: Array<any> };
 import React, { PropTypes } from 'react'
 import _ from 'lodash'
 import { List } from 'material-ui/List'
@@ -22,10 +23,6 @@ function ProjectList(props) {
       }
     </List>
   )
-}
-
-ProjectList.propTypes = {
-  data: PropTypes.array.isRequired,
 }
 
 export default ProjectList

--- a/src/components/PullRequestDiscussion/PullRequestDiscussion.js
+++ b/src/components/PullRequestDiscussion/PullRequestDiscussion.js
@@ -1,3 +1,4 @@
+export type Props = { onSaveComment?: Function };
 import React, { PropTypes } from 'react'
 import { Col, Row } from 'react-bootstrap'
 import _ from 'lodash'
@@ -118,8 +119,6 @@ const PullRequestDiscussion = (props) =>
   </div>
 
 
-PullRequestDiscussion.propTypes = {
-  onSaveComment: PropTypes.func.isRequired,
-}
+;
 
 export default PullRequestDiscussion

--- a/src/components/PullRequestDiscussion/PullRequestDiscussion.js
+++ b/src/components/PullRequestDiscussion/PullRequestDiscussion.js
@@ -1,5 +1,6 @@
-export type Props = { onSaveComment?: Function };
-import React, { PropTypes } from 'react'
+/* @flow */
+
+import React from 'react'
 import { Col, Row } from 'react-bootstrap'
 import _ from 'lodash'
 
@@ -46,8 +47,11 @@ const prComments = [
   },
 ]
 
+export type Props = {
+  onSaveComment?: Function
+}
 
-const PullRequestDiscussion = (props) =>
+const PullRequestDiscussion = (props: Props) =>
   <div>
     <Row>
       <Col md={12}>
@@ -118,7 +122,5 @@ const PullRequestDiscussion = (props) =>
     </Row>
   </div>
 
-
-;
 
 export default PullRequestDiscussion

--- a/src/components/PullRequestDiscussion/index.js
+++ b/src/components/PullRequestDiscussion/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import PullRequestDiscussion from './PullRequestDiscussion'
 export default PullRequestDiscussion

--- a/src/components/PullRequestList/PullRequestList.js
+++ b/src/components/PullRequestList/PullRequestList.js
@@ -1,6 +1,7 @@
+// TODO: add flow annotations
 /* eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 import { ChangesetDelta, TestAvatar } from 'components'
 import { Link } from 'react-router'
@@ -15,15 +16,13 @@ const subHeader = text => (
   </div>
 )
 
-
 export type Props = {
   data?: any,
   id: string,
   projectid: string,
   showFollowIcon?: boolean,
   showRemoveIcon?: boolean,
-};
-
+}
 
 class PullRequestList extends Component {
   constructor(props: Props) {
@@ -32,7 +31,7 @@ class PullRequestList extends Component {
     this.handleSelect = this.handleSelect.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleSelect(activeKey) {
     this.setState({ activeKey })

--- a/src/components/PullRequestList/PullRequestList.js
+++ b/src/components/PullRequestList/PullRequestList.js
@@ -16,12 +16,23 @@ const subHeader = text => (
 )
 
 
+export type Props = {
+  data?: any,
+  id: string,
+  projectid: string,
+  showFollowIcon?: boolean,
+  showRemoveIcon?: boolean,
+};
+
+
 class PullRequestList extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { search: null, activeKey: 3 }
     this.handleSelect = this.handleSelect.bind(this)
   }
+
+  props: Props;
 
   handleSelect(activeKey) {
     this.setState({ activeKey })
@@ -130,14 +141,6 @@ class PullRequestList extends Component {
       </div>
     )
   }
-}
-
-PullRequestList.propTypes = {
-  data: PropTypes.any,
-  id: PropTypes.string.isRequired,
-  projectid: PropTypes.string.isRequired,
-  showFollowIcon: PropTypes.bool,
-  showRemoveIcon: PropTypes.bool,
 }
 
 export default PullRequestList

--- a/src/components/PullRequestList/PullRequestListItem/index.js
+++ b/src/components/PullRequestList/PullRequestListItem/index.js
@@ -12,11 +12,34 @@ const subHeader = text => (
   </div>
 )
 
+export type Props = {
+  id: string,
+  title: string,
+  status: string,
+  username: string,
+  updated: string,
+  link: string,
+  originRepository: string,
+  originBranch: string,
+  originLink: string,
+  destRepository: string,
+  destBranch: string,
+  destLink: string,
+  buildName?: string,
+  buildStatus?: string,
+  buildDate?: string,
+  buildLink?: string,
+  showRemoveIcon?: boolean,
+  onRemoveClick?: Function,
+};
+
 class PullRequestListItem extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.handleRemoveClick = this.handleRemoveClick.bind(this)
   }
+
+  props: Props;
 
   handleRemoveClick() {
     if (this.onRemoveClick) {
@@ -111,27 +134,6 @@ class PullRequestListItem extends Component {
       </ListGroupItem>
     )
   }
-}
-
-PullRequestListItem.propTypes = {
-  id: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  status: PropTypes.string.isRequired,
-  username: PropTypes.string.isRequired,
-  updated: PropTypes.string.isRequired,
-  link: PropTypes.string.isRequired,
-  originRepository: PropTypes.string.isRequired,
-  originBranch: PropTypes.string.isRequired,
-  originLink: PropTypes.string.isRequired,
-  destRepository: PropTypes.string.isRequired,
-  destBranch: PropTypes.string.isRequired,
-  destLink: PropTypes.string.isRequired,
-  buildName: PropTypes.string,
-  buildStatus: PropTypes.string,
-  buildDate: PropTypes.string,
-  buildLink: PropTypes.string,
-  showRemoveIcon: PropTypes.bool,
-  onRemoveClick: PropTypes.func,
 }
 
 export default PullRequestListItem

--- a/src/components/PullRequestList/PullRequestListItem/index.js
+++ b/src/components/PullRequestList/PullRequestListItem/index.js
@@ -1,4 +1,6 @@
-import React, { PropTypes, Component } from 'react'
+// TODO: add flow annotations
+
+import React, { Component } from 'react'
 import { Col, Row, ListGroupItem } from 'react-bootstrap'
 import { TestAvatar } from 'components'
 import { Link } from 'react-router'
@@ -39,7 +41,7 @@ class PullRequestListItem extends Component {
     this.handleRemoveClick = this.handleRemoveClick.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleRemoveClick() {
     if (this.onRemoveClick) {

--- a/src/components/PullRequestList/index.js
+++ b/src/components/PullRequestList/index.js
@@ -1,3 +1,16 @@
+export type Props = {
+  totalPagesCount?: number,
+  activePage?: number,
+  items?: Array<any>,
+  isFetching?: boolean,
+  totalNew?: number,
+  totalInProgress?: number,
+  total?: number,
+  error?: string,
+  showRemoveButton?: boolean,
+  onRemoveClick?: Function,
+};
+
 /* eslint-disable import/no-extraneous-dependencies */
 
 import React, { PropTypes } from 'react'
@@ -42,19 +55,6 @@ function PullRequestList(props) {
       </List>
     </div>
   )
-}
-
-PullRequestList.propTypes = {
-  totalPagesCount: PropTypes.number.isRequired,
-  activePage: PropTypes.number.isRequired,
-  items: PropTypes.array.isRequired,
-  isFetching: PropTypes.bool.isRequired,
-  totalNew: PropTypes.number.isRequired,
-  totalInProgress: PropTypes.number.isRequired,
-  total: PropTypes.number.isRequired,
-  error: PropTypes.string,
-  showRemoveButton: PropTypes.bool,
-  onRemoveClick: PropTypes.func,
 }
 
 export default PullRequestList

--- a/src/components/PullRequestList/index.js
+++ b/src/components/PullRequestList/index.js
@@ -1,19 +1,7 @@
-export type Props = {
-  totalPagesCount?: number,
-  activePage?: number,
-  items?: Array<any>,
-  isFetching?: boolean,
-  totalNew?: number,
-  totalInProgress?: number,
-  total?: number,
-  error?: string,
-  showRemoveButton?: boolean,
-  onRemoveClick?: Function,
-};
-
+/* @flow */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import LinearProgress from 'material-ui/LinearProgress'
 import ErrorMessage from 'components/ErrorMessage'
 import List from 'components/List'
@@ -21,7 +9,22 @@ import PullRequestListItem from './PullRequestListItem'
 
 import './styles.css'
 
-function PullRequestList(props) {
+export type Props = {
+  totalPagesCount?: number,
+  activePage?: number,
+  items: Array<{
+    id: string,
+  }>,
+  isFetching?: boolean,
+  totalNew?: number,
+  totalInProgress?: number,
+  total?: number,
+  error?: string,
+  showRemoveButton?: boolean,
+  onRemoveClick?: Function,
+}
+
+function PullRequestList(props: Props) {
   const {
     items,
     activePage,
@@ -58,4 +61,3 @@ function PullRequestList(props) {
 }
 
 export default PullRequestList
-

--- a/src/components/PullRequestSummary/PullRequestSummary.js
+++ b/src/components/PullRequestSummary/PullRequestSummary.js
@@ -1,3 +1,10 @@
+export type Props = {
+  onAddReviewer?: Function,
+  onToggleReviewers?: Function,
+  pullRequest?: Object,
+  toggleReviewers?: boolean,
+};
+
 /* @flow */
 import moment from 'moment'
 import React, { PropTypes } from 'react'
@@ -64,9 +71,7 @@ export const PullRequestHeader = ({ pullRequest } : PullRequestHeaderProps) =>
   </div>
 
 
-PullRequestHeader.propTypes = {
-  pullRequest: PropTypes.object.isRequired,
-}
+;
 
 type PullRequestSummaryProps = {
   onAddReviewer: Function,
@@ -426,11 +431,6 @@ const PullRequestSummary = (props: PullRequestSummaryProps) =>
   </div>
 
 
-PullRequestSummary.propTypes = {
-  onAddReviewer: PropTypes.func.isRequired,
-  onToggleReviewers: PropTypes.func.isRequired,
-  pullRequest: PropTypes.object.isRequired,
-  toggleReviewers: PropTypes.bool.isRequired,
-}
+;
 
 export default PullRequestSummary

--- a/src/components/PullRequestSummary/PullRequestSummary.js
+++ b/src/components/PullRequestSummary/PullRequestSummary.js
@@ -1,13 +1,6 @@
-export type Props = {
-  onAddReviewer?: Function,
-  onToggleReviewers?: Function,
-  pullRequest?: Object,
-  toggleReviewers?: boolean,
-};
-
 /* @flow */
 import moment from 'moment'
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 
 import type { PullRequestGraphType } from 'ducks/pullRequest'
@@ -70,8 +63,6 @@ export const PullRequestHeader = ({ pullRequest } : PullRequestHeaderProps) =>
     </div>
   </div>
 
-
-;
 
 type PullRequestSummaryProps = {
   onAddReviewer: Function,
@@ -430,7 +421,5 @@ const PullRequestSummary = (props: PullRequestSummaryProps) =>
     </Row>
   </div>
 
-
-;
 
 export default PullRequestSummary

--- a/src/components/PullRequestSummary/index.js
+++ b/src/components/PullRequestSummary/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import PullRequestSummary from './PullRequestSummary'
 export default PullRequestSummary

--- a/src/components/ReduxBreadcrumb/ReduxBreadcrumb.js
+++ b/src/components/ReduxBreadcrumb/ReduxBreadcrumb.js
@@ -1,3 +1,8 @@
+export type Props = {
+  items?: Array<any>,
+  style?: Object,
+};
+
 /* @flow */
 
 import React, { PropTypes } from 'react'
@@ -21,11 +26,6 @@ function ReduxBreadcrumb(props) {
     }
     </div>
   )
-}
-
-ReduxBreadcrumb.propTypes = {
-  items: PropTypes.array,
-  style: PropTypes.object,
 }
 
 export default connect(state => ({

--- a/src/components/ReduxBreadcrumb/ReduxBreadcrumb.js
+++ b/src/components/ReduxBreadcrumb/ReduxBreadcrumb.js
@@ -1,17 +1,17 @@
-export type Props = {
-  items?: Array<any>,
-  style?: Object,
-};
-
 /* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router'
 import { Breadcrumb } from 'react-bootstrap'
 import _ from 'lodash'
 
-function ReduxBreadcrumb(props) {
+export type Props = {
+  items: Array<any>,
+  style: Object,
+}
+
+function ReduxBreadcrumb(props: Props) {
   const { items, style } = props
   return (
     <div>

--- a/src/components/Reviewers/Reviewers.js
+++ b/src/components/Reviewers/Reviewers.js
@@ -4,12 +4,19 @@ import React, { PropTypes, Component } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 import TestAvatar from '../TestAvatar'
 
+export type Props = {
+  reviewers?: any,
+  onAdded?: Function,
+};
+
 class Reviewers extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { search: null, reviewers: this.props.reviewers }
     this.addReviewer = this.addReviewer.bind(this)
   }
+
+  props: Props;
 
   addReviewer(value) {
     const list = this.state.reviewers
@@ -78,11 +85,6 @@ class Reviewers extends Component {
       </div>
     )
   }
-}
-
-Reviewers.propTypes = {
-  reviewers: PropTypes.any,
-  onAdded: PropTypes.func,
 }
 
 export default Reviewers

--- a/src/components/Reviewers/Reviewers.js
+++ b/src/components/Reviewers/Reviewers.js
@@ -1,6 +1,8 @@
+// TODO: add flow annotations
+
 /* eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { Col, Row, ListGroup, ListGroupItem } from 'react-bootstrap'
 import TestAvatar from '../TestAvatar'
 
@@ -16,7 +18,7 @@ class Reviewers extends Component {
     this.addReviewer = this.addReviewer.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   addReviewer(value) {
     const list = this.state.reviewers

--- a/src/components/Reviewers/index.js
+++ b/src/components/Reviewers/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import Reviewers from './Reviewers'
 export default Reviewers

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -5,11 +5,13 @@ import IconButton from 'material-ui/IconButton'
 
 
 class SearchBox extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { visible: false }
     this.handleClick = this.handleClick.bind(this)
   }
+
+  props: Props;
 
   handleClick() {
     const toggle = this.state.visible

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -1,17 +1,16 @@
+// TODO: add flow annotations
+
 import React, { Component } from 'react'
 import TextField from 'material-ui/TextField'
 import Search from 'material-ui/svg-icons/action/search'
 import IconButton from 'material-ui/IconButton'
 
-
 class SearchBox extends Component {
-  constructor(props: Props) {
+  constructor(props) {
     super(props)
     this.state = { visible: false }
     this.handleClick = this.handleClick.bind(this)
   }
-
-  props: Props;
 
   handleClick() {
     const toggle = this.state.visible

--- a/src/components/SearchBox/index.js
+++ b/src/components/SearchBox/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+import SearchBox from './SearchBox'
+export default SearchBox

--- a/src/components/SelectableList/SelectableList.js
+++ b/src/components/SelectableList/SelectableList.js
@@ -1,16 +1,15 @@
+// TODO: add flow annotations
 /* eslint-disable */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { List, makeSelectable } from 'material-ui/List'
 
 function wrapState(ComposedComponent) {
   class selectableList extends Component {
-    constructor(props: Props){
+    constructor(props){
       super(props)
       this.handleRequestChange = this.handleRequestChange.bind(this)
     }
-
-    props: Props;
 
     componentWillMount() {
       this.setState({

--- a/src/components/SelectableList/SelectableList.js
+++ b/src/components/SelectableList/SelectableList.js
@@ -5,10 +5,12 @@ import { List, makeSelectable } from 'material-ui/List'
 
 function wrapState(ComposedComponent) {
   class selectableList extends Component {
-    constructor(props){
+    constructor(props: Props){
       super(props)
       this.handleRequestChange = this.handleRequestChange.bind(this)
     }
+
+    props: Props;
 
     componentWillMount() {
       this.setState({
@@ -34,12 +36,7 @@ function wrapState(ComposedComponent) {
     }
   }
 
-  selectableList.propTypes = {
-      children: PropTypes.node.isRequired,
-      defaultValue: PropTypes.number,
-    }
-
-    return selectableList
+  return selectableList
 }
 
 const SelectableList = wrapState(makeSelectable(List))  // eslint-disable-line new-cap

--- a/src/components/SelectableList/index.js
+++ b/src/components/SelectableList/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+import SelectableList from './SelectableList'
+export default SelectableList

--- a/src/components/SideBar/SideBar.js
+++ b/src/components/SideBar/SideBar.js
@@ -1,11 +1,12 @@
+/* @flow */
+
 /* eslint-disable */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import Drawer from 'material-ui/Drawer'
 import _ from 'lodash'
 import { push } from 'react-router-redux'
 import { connect } from 'react-redux'
-import { SelectableList } from 'components'
 import { ListItem } from 'material-ui/List'
 import { TOGGLE_SIDE_BAR } from 'ducks/sidebar'
 import IconButton from 'material-ui/IconButton'
@@ -13,6 +14,8 @@ import Open from 'material-ui/svg-icons/navigation/menu'
 import { IndexLink } from 'react-router'
 import { Col, Row } from 'react-bootstrap'
 import Scroll from 'react-scroll'
+
+import SelectableList from '../SelectableList'
 import './SideBar.css'
 
 import { DEVELOPER_PERSONA } from 'ducks/session'
@@ -73,7 +76,7 @@ export type Props = {
   width: number,
   hiddenWidth: number,
   items: Array<any>,
-  subitems?: Array<any>,
+  subitems: Array<any>,
   open: boolean,
   sideBarMenuItemStyle?: Object,
   sideBarMenuItemSelectedStyle?: Object,
@@ -84,7 +87,7 @@ export type Props = {
 };
 
 class SideBar extends Component {
-  props: Props;
+  props: Props
   redirect(to) {
     this.props.dispatch(push(to))
   }

--- a/src/components/SideBar/SideBar.js
+++ b/src/components/SideBar/SideBar.js
@@ -69,7 +69,22 @@ const subItem = (icon, title, color, badge, iconbadge, open) => (
   </div>
 )
 
+export type Props = {
+  width: number,
+  hiddenWidth: number,
+  items: Array<any>,
+  subitems?: Array<any>,
+  open: boolean,
+  sideBarMenuItemStyle?: Object,
+  sideBarMenuItemSelectedStyle?: Object,
+  dispatch: Function,
+  defaultValue: number,
+  title: string,
+  persona: string,
+};
+
 class SideBar extends Component {
+  props: Props;
   redirect(to) {
     this.props.dispatch(push(to))
   }
@@ -185,20 +200,6 @@ class SideBar extends Component {
   }
 }
 
-
-SideBar.propTypes = {
-  width: PropTypes.number.isRequired,
-  hiddenWidth: PropTypes.number.isRequired,
-  items: PropTypes.array.isRequired,
-  subitems: PropTypes.array,
-  open: PropTypes.bool.isRequired,
-  sideBarMenuItemStyle: PropTypes.object,
-  sideBarMenuItemSelectedStyle: PropTypes.object,
-  dispatch: PropTypes.func.isRequired,
-  defaultValue: PropTypes.number.isRequired,
-  title: PropTypes.string.isRequired,
-  persona: PropTypes.string.isRequired,
-}
 
 export default connect(state => ({
   open: state.sidebar.open,

--- a/src/components/StepperExtended/StepperExtended.js
+++ b/src/components/StepperExtended/StepperExtended.js
@@ -1,4 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+// TODO: add flow annotations
+
+import React, { Component } from 'react'
 import _ from 'lodash'
 import {
   Step,
@@ -17,7 +19,7 @@ class StepperExtended extends Component {
     }
   }
 
-  props: Props;
+  props: Props
 
   render() {
     return (

--- a/src/components/StepperExtended/StepperExtended.js
+++ b/src/components/StepperExtended/StepperExtended.js
@@ -7,13 +7,17 @@ import {
   StepLabel,
 } from 'material-ui/Stepper'
 
+export type Props = { items?: Array<any> };
+
 class StepperExtended extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       stepIndex: this.props.items.length - 1,
     }
   }
+
+  props: Props;
 
   render() {
     return (
@@ -37,9 +41,5 @@ class StepperExtended extends Component {
   }
 }
 
-
-StepperExtended.propTypes = {
-  items: PropTypes.array,
-}
 
 export default StepperExtended

--- a/src/components/TestAvatar/TestAvatar.js
+++ b/src/components/TestAvatar/TestAvatar.js
@@ -9,11 +9,15 @@ const randomNumber = (minA, maxA) => {
   return Math.floor(Math.random() * (max - min + 1)) + min
 }
 
+export type Props = { style?: Object };
+
 class TestAvatar extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { image: require(`../../media/images/avatars/Avatar${randomNumber(1, 3)}.png`) }
   }
+
+  props: Props;
 
   render() {
     const { style } = this.props
@@ -21,10 +25,6 @@ class TestAvatar extends Component {
       <Avatar src={this.state.image} size={40} style={{ borderRadius: '20%', float: 'left', display: 'table-column', ...style }} />
     )
   }
-}
-
-TestAvatar.propTypes = {
-  style: PropTypes.object,
 }
 
 export default TestAvatar

--- a/src/components/TestAvatar/TestAvatar.js
+++ b/src/components/TestAvatar/TestAvatar.js
@@ -1,6 +1,7 @@
+// TODO: add flow annotations
 /* eslint-disable */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import Avatar from 'material-ui/Avatar'
 
 const randomNumber = (minA, maxA) => {
@@ -17,7 +18,7 @@ class TestAvatar extends Component {
     this.state = { image: require(`../../media/images/avatars/Avatar${randomNumber(1, 3)}.png`) }
   }
 
-  props: Props;
+  props: Props
 
   render() {
     const { style } = this.props

--- a/src/components/TestAvatar/index.js
+++ b/src/components/TestAvatar/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import TestAvatar from './TestAvatar'
 export default TestAvatar

--- a/src/components/TextEditorBox/StyleControls.js
+++ b/src/components/TextEditorBox/StyleControls.js
@@ -1,12 +1,6 @@
-export type Props = {
-  editorState?: Object,
-  // onToogleInlineStyle: PropTypes.func.isRequired,
-  onToogleBlockType?: Function,
-  activeColor?: string,
-  style?: Object,
-};
+/* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import Bold from 'material-ui/svg-icons/editor/format-bold'
 import Italic from 'material-ui/svg-icons/editor/format-italic'
 import Underline from 'material-ui/svg-icons/editor/format-underlined'
@@ -40,8 +34,19 @@ const BLOCK_TYPES = [
 //   { value: 6, style: 'header-six' },
 // ]
 
+export type Props = {
+  editorState: {
+    getCurrentInlineStyle: Function,
+    getSelection: Function,
+    getCurrentContent: Function,
+  },
+  onToogleBlockType: Function,
+  onToogleInlineStyle: Function,
+  activeColor?: string,
+  style?: Object,
+}
 
-const StyleControls = (props) => {
+const StyleControls = (props: Props) => {
   const currentStyle = props.editorState.getCurrentInlineStyle()
   const { editorState, style } = props
   const selection = editorState.getSelection()
@@ -98,6 +103,5 @@ const StyleControls = (props) => {
   )
 }
 
-;
 
 export default StyleControls

--- a/src/components/TextEditorBox/StyleControls.js
+++ b/src/components/TextEditorBox/StyleControls.js
@@ -1,3 +1,11 @@
+export type Props = {
+  editorState?: Object,
+  // onToogleInlineStyle: PropTypes.func.isRequired,
+  onToogleBlockType?: Function,
+  activeColor?: string,
+  style?: Object,
+};
+
 import React, { PropTypes } from 'react'
 import Bold from 'material-ui/svg-icons/editor/format-bold'
 import Italic from 'material-ui/svg-icons/editor/format-italic'
@@ -90,12 +98,6 @@ const StyleControls = (props) => {
   )
 }
 
-StyleControls.propTypes = {
-  editorState: PropTypes.object.isRequired,
-  // onToogleInlineStyle: PropTypes.func.isRequired,
-  onToogleBlockType: PropTypes.func.isRequired,
-  activeColor: PropTypes.string,
-  style: PropTypes.object,
-}
+;
 
 export default StyleControls

--- a/src/components/TextEditorBox/TextEditorBox.js
+++ b/src/components/TextEditorBox/TextEditorBox.js
@@ -1,6 +1,7 @@
+// TODO: add flow annotations
 /* eslint-disable */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { fromJS } from 'immutable'
 import { EditorState, RichUtils, ContentState } from 'draft-js'
 import 'draft-js/dist/Draft.css'
@@ -71,7 +72,7 @@ class TextEditorBox extends Component {
 
   }
 
-  props: Props;
+  props: Props
 
   onChange(editorState) {
     this.setState({

--- a/src/components/TextEditorBox/TextEditorBox.js
+++ b/src/components/TextEditorBox/TextEditorBox.js
@@ -31,8 +31,24 @@ const hashtagPlugin = createHashtagPlugin()
 
 const plugins = [emojiPlugin, mentionPlugin, linkifyPlugin, hashtagPlugin]
 
+export type Props = {
+  mentions?: Array<any>,
+  onTextChanged?: Function,
+  readOnly?: boolean,
+  text?: any,
+  placeholder?: // height: PropTypes.string,
+  string,
+  hideStyleControls?: boolean,
+  simpleText?: boolean,
+  children?: number | string | React.Element | Array<any>,
+  header?: number | string | React.Element | Array<any>,
+  style?: Object,
+  editorStyle?: Object,
+  styleControlsStyle?: Object,
+};
+
 class TextEditorBox extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
 
     this.state = {
@@ -54,6 +70,8 @@ class TextEditorBox extends Component {
     this.focus = this.focus.bind(this)
 
   }
+
+  props: Props;
 
   onChange(editorState) {
     this.setState({
@@ -162,22 +180,6 @@ class TextEditorBox extends Component {
       </div>
     )
   }
-}
-
-TextEditorBox.propTypes = {
-  mentions: PropTypes.array,
-  onTextChanged: PropTypes.func,
-  readOnly: PropTypes.bool,
-  text: PropTypes.any,
-  // height: PropTypes.string,
-  placeholder: PropTypes.string,
-  hideStyleControls: PropTypes.bool,
-  simpleText: PropTypes.bool,
-  children: PropTypes.node,
-  header: PropTypes.node,
-  style: PropTypes.object,
-  editorStyle: PropTypes.object,
-  styleControlsStyle: PropTypes.object,
 }
 
 export default TextEditorBox

--- a/src/components/TextEditorBox/index.js
+++ b/src/components/TextEditorBox/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import TextEditorBox from './TextEditorBox'
 export default TextEditorBox

--- a/src/components/Tree/Tree.js
+++ b/src/components/Tree/Tree.js
@@ -1,3 +1,11 @@
+export type Props = { //clickHandler: PropTypes.func.isRequired,
+//childrenProp: PropTypes.string.isRequired,
+// primaryTextProp: PropTypes.string.isRequired,
+//secondaryTextProp: PropTypes.string,
+//inset: PropTypes.number,
+//valueProp: PropTypes.string.isRequired,
+data?: Array<any> };
+
 import React, { PropTypes } from 'react'
 import _ from 'lodash'
 import { List } from 'material-ui/List'
@@ -23,16 +31,6 @@ function Tree(props) {
       }
     </List>
   )
-}
-
-Tree.propTypes = {
-  data: PropTypes.array.isRequired,
-  //clickHandler: PropTypes.func.isRequired,
-  //childrenProp: PropTypes.string.isRequired,
- // primaryTextProp: PropTypes.string.isRequired,
-  //secondaryTextProp: PropTypes.string,
-  //inset: PropTypes.number,
-  //valueProp: PropTypes.string.isRequired,
 }
 
 export default Tree

--- a/src/components/Tree/Tree.js
+++ b/src/components/Tree/Tree.js
@@ -1,12 +1,6 @@
-export type Props = { //clickHandler: PropTypes.func.isRequired,
-//childrenProp: PropTypes.string.isRequired,
-// primaryTextProp: PropTypes.string.isRequired,
-//secondaryTextProp: PropTypes.string,
-//inset: PropTypes.number,
-//valueProp: PropTypes.string.isRequired,
-data?: Array<any> };
+// TODO: add flow annotations
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import _ from 'lodash'
 import { List } from 'material-ui/List'
 

--- a/src/components/Tree/TreeItem.js
+++ b/src/components/Tree/TreeItem.js
@@ -79,6 +79,7 @@ function TreeItem({
               secondaryTextProp={secondaryTextProp}
               valueProp={valueProp}
               inset={inset + 30}
+              palette={palette}
             />
         )
       }

--- a/src/components/Tree/TreeItem.js
+++ b/src/components/Tree/TreeItem.js
@@ -1,18 +1,22 @@
-export type Props = {
-  item?: Object,
-  clickHandler?: Function,
-  childrenProp?: string,
-  primaryTextProp?: string,
-  secondaryTextProp?: string,
-  inset?: number,
-  valueProp?: string,
-  palette?: Object,
-};
+/* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import _ from 'lodash'
 import { ListItem } from 'material-ui/List'
 import FolderClosedIcon from 'material-ui/svg-icons/file/folder'
+
+export type Props = {
+  item: Object,
+  clickHandler: Function,
+  childrenProp: string,
+  primaryTextProp: string,
+  secondaryTextProp: string,
+  inset: number,
+  valueProp: string,
+  palette: {
+    primary1Color: string,
+  },
+}
 
 function TreeItem({
   item,
@@ -23,7 +27,7 @@ function TreeItem({
   clickHandler,
   inset,
   palette,
-}) {
+} : Props) {
   const primaryText = item[primaryTextProp]
   const secondaryText = secondaryTextProp ? item[secondaryTextProp] : ''
   const value = item[valueProp]

--- a/src/components/Tree/TreeItem.js
+++ b/src/components/Tree/TreeItem.js
@@ -1,3 +1,14 @@
+export type Props = {
+  item?: Object,
+  clickHandler?: Function,
+  childrenProp?: string,
+  primaryTextProp?: string,
+  secondaryTextProp?: string,
+  inset?: number,
+  valueProp?: string,
+  palette?: Object,
+};
+
 import React, { PropTypes } from 'react'
 import _ from 'lodash'
 import { ListItem } from 'material-ui/List'
@@ -69,17 +80,6 @@ function TreeItem({
       }
       />
     </div>)
-}
-
-TreeItem.propTypes = {
-  item: PropTypes.object.isRequired,
-  clickHandler: PropTypes.func.isRequired,
-  childrenProp: PropTypes.string.isRequired,
-  primaryTextProp: PropTypes.string.isRequired,
-  secondaryTextProp: PropTypes.string,
-  inset: PropTypes.number,
-  valueProp: PropTypes.string.isRequired,
-  palette: PropTypes.object.isRequired,
 }
 
 export default TreeItem

--- a/src/components/UserAvatar/UserAvatar.js
+++ b/src/components/UserAvatar/UserAvatar.js
@@ -1,3 +1,8 @@
+export type Props = {
+  src?: string,
+  style?: Object,
+};
+
 /* @flow */
 import React, { PropTypes } from 'react'
 import Avatar from 'material-ui/Avatar'
@@ -15,11 +20,6 @@ function UserAvatar(props: Props) {
       style={{ borderRadius: '20%', ...props.style }}
     />
   )
-}
-
-UserAvatar.propTypes = {
-  src: PropTypes.string,
-  style: PropTypes.object,
 }
 
 export default UserAvatar

--- a/src/components/UserAvatar/UserAvatar.js
+++ b/src/components/UserAvatar/UserAvatar.js
@@ -1,10 +1,5 @@
-export type Props = {
-  src?: string,
-  style?: Object,
-};
-
 /* @flow */
-import React, { PropTypes } from 'react'
+import React from 'react'
 import Avatar from 'material-ui/Avatar'
 
 type Props = {

--- a/src/components/UserAvatar/index.js
+++ b/src/components/UserAvatar/index.js
@@ -1,2 +1,3 @@
+/* @flow */
 import UserAvatar from './UserAvatar'
 export default UserAvatar

--- a/src/components/UserFilter/UserFilter.js
+++ b/src/components/UserFilter/UserFilter.js
@@ -3,8 +3,18 @@ import Select from 'react-select'
 import 'react-select/dist/react-select.css'
 import { reviewers } from '../../api/testData'
 
+export type Props = {
+  defaultValue?: // project: PropTypes.string.isRequired,
+  Array<any>,
+  placeholder?: // style: PropTypes.object,
+  // onChange: PropTypes.func,
+  // width: PropTypes.string,
+  string,
+  disabled?: boolean,
+};
+
 class UserFilter extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       options: reviewers,
@@ -12,6 +22,8 @@ class UserFilter extends Component {
     }
     this.handleSelectChange = this.handleSelectChange.bind(this)
   }
+
+  props: Props;
 
   handleSelectChange(value) {
     this.setState({ value })
@@ -33,16 +45,6 @@ class UserFilter extends Component {
       </div>
     )
   }
-}
-
-UserFilter.propTypes = {
-  // project: PropTypes.string.isRequired,
-  defaultValue: PropTypes.array,
-  // style: PropTypes.object,
-  // onChange: PropTypes.func,
-  // width: PropTypes.string,
-  placeholder: PropTypes.string,
-  disabled: PropTypes.bool,
 }
 
 export default UserFilter

--- a/src/components/UserFilter/UserFilter.js
+++ b/src/components/UserFilter/UserFilter.js
@@ -1,4 +1,6 @@
-import React, { PropTypes, Component } from 'react'
+// TODO: add flow annotations
+
+import React, { Component } from 'react'
 import Select from 'react-select'
 import 'react-select/dist/react-select.css'
 import { reviewers } from '../../api/testData'
@@ -23,7 +25,7 @@ class UserFilter extends Component {
     this.handleSelectChange = this.handleSelectChange.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleSelectChange(value) {
     this.setState({ value })

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
+/* @flow */
 // FIXME: stop maintaining this file and use standard MyComponent/index.js file
 // to expose the component. This level of indirection is error prone.
 

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,6 +1,6 @@
 // TODO: add flow annotations
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
@@ -28,7 +28,7 @@ class App extends Component {
     }
   }
 
-  props: Props;
+  props: Props
 
   render() {
     const childrenWithProps = React.Children.map(this.props.children,

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -14,14 +14,21 @@ const APP_THEME = 'cyan'
 const theme = require(`../../theme/ui/${APP_THEME}`)
 const muiTheme = getMuiTheme(theme)
 
+export type Props = {
+  children: Object,
+  open: boolean,
+};
+
 class App extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       sideBarWidth: 280,
       hiddenSideBarWidth: 60,
     }
   }
+
+  props: Props;
 
   render() {
     const childrenWithProps = React.Children.map(this.props.children,
@@ -60,11 +67,6 @@ class App extends Component {
       </MuiThemeProvider>
     )
   }
-}
-
-App.propTypes = {
-  children: PropTypes.object.isRequired,
-  open: PropTypes.bool.isRequired,
 }
 
 export default connect(state => ({

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -9,11 +9,15 @@ import { NotificationList } from 'components'
 import Helmet from 'react-helmet'
 import { connect } from 'react-redux'
 
+export type Props = { profile?: Object };
+
 class Home extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { open: true }
   }
+
+  props: Props;
 
   render() {
     return (
@@ -30,10 +34,6 @@ class Home extends Component {
       </div>
     )
   }
-}
-
-Home.propTypes = {
-  profile: PropTypes.object,
 }
 
 export default connect(state => ({

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import Col from 'react-bootstrap/lib/Col'
 import Row from 'react-bootstrap/lib/Row'
 import { NotificationList } from 'components'
@@ -17,7 +17,7 @@ class Home extends Component {
     this.state = { open: true }
   }
 
-  props: Props;
+  props: Props
 
   render() {
     return (

--- a/src/containers/Html/index.js
+++ b/src/containers/Html/index.js
@@ -1,3 +1,4 @@
+export type Props = { assets?: Object };
 // TODO: add flow annotations
 
 import React, { PropTypes } from 'react'
@@ -62,10 +63,6 @@ function Html({ assets }) {
       </body>
     </html>
   )
-}
-
-Html.propTypes = {
-  assets: PropTypes.object,
 }
 
 export default Html

--- a/src/containers/Html/index.js
+++ b/src/containers/Html/index.js
@@ -1,10 +1,18 @@
-export type Props = { assets?: Object };
-// TODO: add flow annotations
+/* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import Helmet from 'react-helmet'
 
-function Html({ assets }) {
+export type Props = {
+  assets: {
+    styles: Object,
+    javascript: {
+      main: string,
+    },
+  },
+}
+
+function Html({ assets }: Props) {
   const head = Helmet.rewind()
 
   const htmlStyle = {

--- a/src/containers/Login/index.js
+++ b/src/containers/Login/index.js
@@ -1,3 +1,4 @@
+export type Props = { assets?: Object };
 /* @flow */
 
 import React, { PropTypes } from 'react'
@@ -83,10 +84,6 @@ function ServerLogin() {
       </body>
     </html>
   )
-}
-
-ServerLogin.propTypes = {
-  assets: PropTypes.object,
 }
 
 export default ServerLogin

--- a/src/containers/Login/index.js
+++ b/src/containers/Login/index.js
@@ -1,7 +1,6 @@
-export type Props = { assets?: Object };
 /* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import Helmet from 'react-helmet'
 import { routes } from 'universal/constants'
 

--- a/src/containers/Project/Changelog/index.js
+++ b/src/containers/Project/Changelog/index.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { BranchSelect, ChangesetList } from 'components'
 import { connect } from 'react-redux'
 import { Row, Col, Button, ButtonGroup } from 'react-bootstrap'
@@ -15,7 +15,6 @@ export type Props = {
   params: Object,
   data: Array<any>,
 };
-
 
 class Changelog extends Component {
   constructor(props: Props) {
@@ -35,7 +34,7 @@ class Changelog extends Component {
     this.handleChange = this.handleChange.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleTouchTap() {
     this.setState({

--- a/src/containers/Project/Changelog/index.js
+++ b/src/containers/Project/Changelog/index.js
@@ -11,8 +11,14 @@ import { Sticky, StickyContainer } from 'react-sticky'
 import { prChangesetList3, prChangesetList1, prChangesetList2 } from '../../../api/testPullRequest'
 
 
+export type Props = {
+  params: Object,
+  data: Array<any>,
+};
+
+
 class Changelog extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
 
     this.state = {
@@ -28,6 +34,8 @@ class Changelog extends Component {
     this.handleRequestClose = this.handleRequestClose.bind(this)
     this.handleChange = this.handleChange.bind(this)
   }
+
+  props: Props;
 
   handleTouchTap() {
     this.setState({
@@ -159,11 +167,6 @@ class Changelog extends Component {
   }
 }
 
-
-Changelog.propTypes = {
-  params: PropTypes.object.isRequired,
-  data: PropTypes.array.isRequired,
-}
 
 export default connect(state => ({ // eslint-disable-line no-unused-vars
   data: [...prChangesetList1, ...prChangesetList2, ...prChangesetList3],

--- a/src/containers/Project/Changeset/index.js
+++ b/src/containers/Project/Changeset/index.js
@@ -1,3 +1,4 @@
+export type Props = { params?: Object };
 // TODO: add flow annotations
 
 import React, { PropTypes } from 'react'
@@ -47,10 +48,6 @@ function Changeset({ params: { hash } }) {
       <Element name="page-bottom" />
     </div>
   )
-}
-
-Changeset.propTypes = {
-  params: PropTypes.object.isRequired,
 }
 
 export default Changeset

--- a/src/containers/Project/Changeset/index.js
+++ b/src/containers/Project/Changeset/index.js
@@ -1,17 +1,25 @@
-export type Props = { params?: Object };
-// TODO: add flow annotations
+/* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import Helmet from 'react-helmet'
-import { ChangesetFileList, CodeDiffView, ChangesetGroupedList, Divider } from 'components'
 import { Button, ButtonGroup } from 'react-bootstrap'
 import Scroll from 'react-scroll'
+
+import ChangesetFileList from 'components/ChangesetFileList'
+import CodeDiffView from 'components/CodeDiffView'
+import ChangesetGroupedList from 'components/ChangesetGroupedList'
+import Divider from 'components/Divider'
 import { PullRequestData, prChangesetList } from '../../../api/testPullRequest'
 
 const Element = Scroll.Element
 
+export type Props = {
+  params: {
+    hash: string,
+  }
+};
 
-function Changeset({ params: { hash } }) {
+function Changeset({ params: { hash } }: Props) {
   const openPrButtonStyle = {
     backgroundColor: '#1fb5ad',
     borderColor: '#1fb5ad',

--- a/src/containers/Project/File/index.js
+++ b/src/containers/Project/File/index.js
@@ -1,6 +1,6 @@
 // TODO: add flow annotations
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import Helmet from 'react-helmet'
 import _ from 'lodash'
 import moment from 'moment'
@@ -20,13 +20,9 @@ import { changesets } from '../../../api/testData'
 
 export type Props = {
   params: Object,
-  file: // location: PropTypes.object.isRequired,
-  Object,
-  author: // dispatch: PropTypes.func,
-  // theme: PropTypes.object,
-  string,
+  file: Object,
+  author: string,
 };
-
 
 class File extends Component {
   constructor(props: Props) {
@@ -34,8 +30,6 @@ class File extends Component {
     this.state = { code: props.file, comments: [] }
     this.onSaveComment = this.onSaveComment.bind(this)
   }
-
-  props: Props;
 
   onSaveComment(message) {
     const comments = this.state.comments
@@ -49,6 +43,8 @@ class File extends Component {
       comments,
     })
   }
+
+  props: Props
 
   // on(newCode) {
   //   this.setState({

--- a/src/containers/Project/File/index.js
+++ b/src/containers/Project/File/index.js
@@ -18,12 +18,24 @@ import {
 import { changesets } from '../../../api/testData'
 
 
+export type Props = {
+  params: Object,
+  file: // location: PropTypes.object.isRequired,
+  Object,
+  author: // dispatch: PropTypes.func,
+  // theme: PropTypes.object,
+  string,
+};
+
+
 class File extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { code: props.file, comments: [] }
     this.onSaveComment = this.onSaveComment.bind(this)
   }
+
+  props: Props;
 
   onSaveComment(message) {
     const comments = this.state.comments
@@ -194,15 +206,6 @@ class File extends Component {
       </div>
     )
   }
-}
-
-File.propTypes = {
-  params: PropTypes.object.isRequired,
-  // location: PropTypes.object.isRequired,
-  file: PropTypes.object.isRequired,
- // dispatch: PropTypes.func,
-  author: PropTypes.string.isRequired,
- // theme: PropTypes.object,
 }
 
 export default connect(state => ({

--- a/src/containers/Project/Files/index.js
+++ b/src/containers/Project/Files/index.js
@@ -18,14 +18,25 @@ import { Sticky, StickyContainer } from 'react-sticky'
 import { projectFilesTestData, changesets } from '../../../api/testData'
 
 
+export type Props = {
+  pathname: string,
+  data: Array<any>,
+  dispatch: Function,
+  location: Object,
+  params: Object,
+};
+
+
 class Files extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.clickHandler = this.clickHandler.bind(this)
     this.findChild = this.findChild.bind(this)
     this.updateCurrentNode = this.updateCurrentNode.bind(this)
     this.state = { currentNode: this.props.data }
   }
+
+  props: Props;
 
   componentDidMount() {
     if (this.props.pathname.endsWith('/files')) {
@@ -175,14 +186,6 @@ class Files extends Component {
       </div>
     )
   }
-}
-
-Files.propTypes = {
-  pathname: PropTypes.string.isRequired,
-  data: PropTypes.array.isRequired,
-  dispatch: PropTypes.func.isRequired,
-  location: PropTypes.object.isRequired,
-  params: PropTypes.object.isRequired,
 }
 
 export default connect(state => ({

--- a/src/containers/Project/Files/index.js
+++ b/src/containers/Project/Files/index.js
@@ -1,6 +1,6 @@
 // TODO: add flow annotations
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { FileList, BranchSelect, ReduxBreadcrumb, Filter } from 'components'
 import urljoin from 'url-join'
 import _ from 'lodash'
@@ -26,7 +26,6 @@ export type Props = {
   params: Object,
 };
 
-
 class Files extends Component {
   constructor(props: Props) {
     super(props)
@@ -35,8 +34,6 @@ class Files extends Component {
     this.updateCurrentNode = this.updateCurrentNode.bind(this)
     this.state = { currentNode: this.props.data }
   }
-
-  props: Props;
 
   componentDidMount() {
     if (this.props.pathname.endsWith('/files')) {
@@ -74,6 +71,8 @@ class Files extends Component {
       result: items.length > 1 ? items.length - 1 : 0,
     })
   }
+
+  props: Props
 
   findChild(nodes, path) {
     if (!nodes.length || !path.length) {

--- a/src/containers/Project/Issues/index.js
+++ b/src/containers/Project/Issues/index.js
@@ -1,3 +1,7 @@
+export type Props = { // isFetching: PropTypes.bool.isRequired,
+// errorMessage: PropTypes.string,
+params?: Object };
+
 // TODO: add flow annotations
 
 import React, { PropTypes } from 'react'
@@ -11,12 +15,6 @@ function Issues({ params: { prid } }) {
       <h3>Issues in project {prid}</h3>
     </div>
   )
-}
-
-Issues.propTypes = {
-  // isFetching: PropTypes.bool.isRequired,
-  // errorMessage: PropTypes.string,
-  params: PropTypes.object.isRequired,
 }
 
 export default connect(

--- a/src/containers/Project/Issues/index.js
+++ b/src/containers/Project/Issues/index.js
@@ -1,14 +1,16 @@
-export type Props = { // isFetching: PropTypes.bool.isRequired,
-// errorMessage: PropTypes.string,
-params?: Object };
+/* @flow */
 
-// TODO: add flow annotations
-
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import Helmet from 'react-helmet'
 
-function Issues({ params: { prid } }) {
+export type Props = {
+  params: {
+    prid: string
+  }
+};
+
+function Issues({ params: { prid } }: Props) {
   return (
     <div>
       <Helmet title="Issues" />

--- a/src/containers/Project/NewPullRequest/index.js
+++ b/src/containers/Project/NewPullRequest/index.js
@@ -10,8 +10,14 @@ import { connect } from 'react-redux'
 import { reviewers as reviewersTestData } from '../../../api/testData'
 import { NewPullRequestData } from '../../../api/testPullRequest'
 
+export type Props = {
+  params?: Object,
+  theme?: // reviewers: PropTypes.array,
+  Object,
+};
+
 class NewPullRequest extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       from: 'default',
@@ -25,6 +31,8 @@ class NewPullRequest extends Component {
     this.handleToChange = this.handleToChange.bind(this)
     this.handleTitleChange = this.handleTitleChange.bind(this)
   }
+
+  props: Props;
 
   handleFromChange(value) {
     this.setState({ from: value })
@@ -118,12 +126,6 @@ class NewPullRequest extends Component {
       </div>
     )
   }
-}
-
-NewPullRequest.propTypes = {
-  params: PropTypes.object,
-  theme: PropTypes.object,
-  // reviewers: PropTypes.array,
 }
 
 export default connect(state => ({ // eslint-disable-line no-unused-vars

--- a/src/containers/Project/NewPullRequest/index.js
+++ b/src/containers/Project/NewPullRequest/index.js
@@ -1,6 +1,6 @@
 // TODO: add flow annotations
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import Helmet from 'react-helmet'
 import { BranchSelect, TextEditorBox, UserFilter, CodeDiffView } from 'components'
 import FlatButton from 'material-ui/FlatButton'
@@ -32,7 +32,7 @@ class NewPullRequest extends Component {
     this.handleTitleChange = this.handleTitleChange.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleFromChange(value) {
     this.setState({ from: value })

--- a/src/containers/Project/Overview/index.js
+++ b/src/containers/Project/Overview/index.js
@@ -1,12 +1,17 @@
-export type Props = { params?: Object };
-// TODO: add flow annotations
+/* @flow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import Helmet from 'react-helmet'
 import { Row, Col, ListGroup, ListGroupItem } from 'react-bootstrap'
 import { prDescription } from '../../../api/testData'
 
-function Overview({ params: { id } }) {
+export type Props = {
+  params: {
+    id: string,
+  }
+}
+
+function Overview({ params: { id } }: Props) {
   return (
     <div>
       <Helmet title={`Project ${id}`} />

--- a/src/containers/Project/Overview/index.js
+++ b/src/containers/Project/Overview/index.js
@@ -1,3 +1,4 @@
+export type Props = { params?: Object };
 // TODO: add flow annotations
 
 import React, { PropTypes } from 'react'
@@ -32,10 +33,6 @@ function Overview({ params: { id } }) {
       </div>
     </div>
   )
-}
-
-Overview.propTypes = {
-  params: PropTypes.object.isRequired,
 }
 
 export default Overview

--- a/src/containers/Project/Project/index.js
+++ b/src/containers/Project/Project/index.js
@@ -1,15 +1,17 @@
+/* @flow */
+
+import React from 'react'
+import Helmet from 'react-helmet'
+
 export type Props = {
-  params?: Object,
+  params: {
+    id: string,
+  },
   children?: Object,
   theme?: Object,
 };
 
-// TODO: add flow annotations
-
-import React, { PropTypes } from 'react'
-import Helmet from 'react-helmet'
-
-function Project(props) {
+function Project(props: Props) {
   const { theme } = props
   const childrenWithProps = React.Children.map(props.children,
     child => React.cloneElement(child, {

--- a/src/containers/Project/Project/index.js
+++ b/src/containers/Project/Project/index.js
@@ -1,3 +1,9 @@
+export type Props = {
+  params?: Object,
+  children?: Object,
+  theme?: Object,
+};
+
 // TODO: add flow annotations
 
 import React, { PropTypes } from 'react'
@@ -17,12 +23,6 @@ function Project(props) {
       {childrenWithProps}
     </div>
   )
-}
-
-Project.propTypes = {
-  params: PropTypes.object.isRequired,
-  children: PropTypes.object,
-  theme: PropTypes.object,
 }
 
 export default Project

--- a/src/containers/Project/PullRequest/Layouts/LayoutDeveloper.js
+++ b/src/containers/Project/PullRequest/Layouts/LayoutDeveloper.js
@@ -33,8 +33,10 @@ const tabTitle = (text, badge) => (
 
 const downloadIcon = <i className="fa fa-download" aria-hidden="true" />
 
+export type Props = { pullRequest: Object };
+
 class LayoutDeveloper extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       value: null,
@@ -47,6 +49,8 @@ class LayoutDeveloper extends Component {
     this.toggleReviewers = this.toggleReviewers.bind(this)
     this.handleSelect = this.handleSelect.bind(this)
   }
+
+  props: Props;
 
   handleChange(event, index, value) {
     this.setState({
@@ -124,10 +128,6 @@ class LayoutDeveloper extends Component {
       </div>
     )
   }
-}
-
-LayoutDeveloper.propTypes = {
-  pullRequest: PropTypes.object.isRequired,
 }
 
 export default LayoutDeveloper

--- a/src/containers/Project/PullRequest/Layouts/LayoutDeveloper.js
+++ b/src/containers/Project/PullRequest/Layouts/LayoutDeveloper.js
@@ -1,4 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+// TODO: add flow annotations
+
+import React, { Component } from 'react'
 import { Badge, Tabs, Tab } from 'react-bootstrap'
 import Scroll from 'react-scroll'
 
@@ -50,7 +52,7 @@ class LayoutDeveloper extends Component {
     this.handleSelect = this.handleSelect.bind(this)
   }
 
-  props: Props;
+  props: Props
 
   handleChange(event, index, value) {
     this.setState({

--- a/src/containers/Project/PullRequest/Layouts/LayoutGuardian.js
+++ b/src/containers/Project/PullRequest/Layouts/LayoutGuardian.js
@@ -19,7 +19,7 @@ import {
 const Element = Scroll.Element
 
 class LayoutGuardian extends Component {
-  constructor(props: Props) {
+  constructor(props) {
     super(props)
     this.state = {
       value: null,
@@ -31,8 +31,6 @@ class LayoutGuardian extends Component {
     this.addReviewer = this.addReviewer.bind(this)
     this.toggleReviewers = this.toggleReviewers.bind(this)
   }
-
-  props: Props;
 
   handleChange(event, index, value) {
     this.setState({

--- a/src/containers/Project/PullRequest/Layouts/LayoutGuardian.js
+++ b/src/containers/Project/PullRequest/Layouts/LayoutGuardian.js
@@ -19,7 +19,7 @@ import {
 const Element = Scroll.Element
 
 class LayoutGuardian extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
       value: null,
@@ -31,6 +31,8 @@ class LayoutGuardian extends Component {
     this.addReviewer = this.addReviewer.bind(this)
     this.toggleReviewers = this.toggleReviewers.bind(this)
   }
+
+  props: Props;
 
   handleChange(event, index, value) {
     this.setState({

--- a/src/containers/Project/PullRequest/Overview/index.js
+++ b/src/containers/Project/PullRequest/Overview/index.js
@@ -1,6 +1,6 @@
 // TODO: add flow annotations
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { UserFilter, Label, TextEditorBox, Comment, NewComment } from 'components'
 import { Row, Col } from 'react-bootstrap'
 import moment from 'moment'
@@ -9,22 +9,17 @@ import _ from 'lodash'
 import { connect } from 'react-redux'
 
 export type Props = {
-  id: // params: PropTypes.object,
-  // theme: PropTypes.object,
-  // reviewers: PropTypes.array,
-  string,
+  id: string,
   user?: string,
   data?: Object,
   commentAuthor?: string,
-};
+}
 
 class Overview extends Component {
   constructor(props: Props) {
     super(props)
     this.state = { pullRequest: props.data, comments: [], changed: false }
   }
-
-  props: Props;
 
   onSaveComment(message) {
     const comments = this.state.comments
@@ -42,6 +37,8 @@ class Overview extends Component {
 
     this.handleTitleChange = this.handleTitleChange.bind(this)
   }
+
+  props: Props
 
   handleTitleChange(event) {
     const pullRequest = this.state.pullRequest

--- a/src/containers/Project/PullRequest/Overview/index.js
+++ b/src/containers/Project/PullRequest/Overview/index.js
@@ -8,11 +8,23 @@ import TextField from 'material-ui/TextField'
 import _ from 'lodash'
 import { connect } from 'react-redux'
 
+export type Props = {
+  id: // params: PropTypes.object,
+  // theme: PropTypes.object,
+  // reviewers: PropTypes.array,
+  string,
+  user?: string,
+  data?: Object,
+  commentAuthor?: string,
+};
+
 class Overview extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { pullRequest: props.data, comments: [], changed: false }
   }
+
+  props: Props;
 
   onSaveComment(message) {
     const comments = this.state.comments
@@ -122,16 +134,6 @@ class Overview extends Component {
       </div>
     )
   }
-}
-
-Overview.propTypes = {
-  // params: PropTypes.object,
-  // theme: PropTypes.object,
-  // reviewers: PropTypes.array,
-  id: PropTypes.string.isRequired,
-  user: PropTypes.string,
-  data: PropTypes.object,
-  commentAuthor: PropTypes.string,
 }
 
 export default connect(state => ({

--- a/src/containers/Project/PullRequest/StickyActionBar/index.js
+++ b/src/containers/Project/PullRequest/StickyActionBar/index.js
@@ -1,6 +1,6 @@
-// TODO: add flow annotations
+/* @flow */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { Button, ButtonGroup, DropdownButton, MenuItem, Row, Col } from 'react-bootstrap'
 import { Sticky } from 'react-sticky'
 import { connect } from 'react-redux'
@@ -17,7 +17,7 @@ export type Props = {
 };
 
 class StickyActionBar extends Component {
-  props: Props;
+  props: Props
 
   changePersona(persona) {
     this.props.dispatch({ type: USER_PERSONA, persona })

--- a/src/containers/Project/PullRequest/StickyActionBar/index.js
+++ b/src/containers/Project/PullRequest/StickyActionBar/index.js
@@ -11,7 +11,13 @@ import {
   USER_PERSONA,
 } from 'ducks/session'
 
+export type Props = {
+  persona: string,
+  dispatch: Function,
+};
+
 class StickyActionBar extends Component {
+  props: Props;
 
   changePersona(persona) {
     this.props.dispatch({ type: USER_PERSONA, persona })
@@ -120,11 +126,6 @@ class StickyActionBar extends Component {
       </Sticky>
     )
   }
-}
-
-StickyActionBar.propTypes = {
-  persona: PropTypes.string.isRequired,
-  dispatch: PropTypes.func.isRequired,
 }
 
 export default connect(state => ({

--- a/src/containers/Project/PullRequest/index.js
+++ b/src/containers/Project/PullRequest/index.js
@@ -30,7 +30,16 @@ type Props = {
   pullRequest: ?PullRequestGraphType,
 };
 
+export type Props = {
+  dispatch: Function,
+  isFetching: boolean,
+  params: Object,
+  persona: DEVELOPER_PERSONA | MANAGER_PERSONA | GUARDIAN_PERSONA,
+  pullRequest?: Object,
+};
+
 class PullRequest extends Component {
+  props: Props;
 
   componentDidMount() {
     const { dispatch, params } = this.props
@@ -69,15 +78,6 @@ class PullRequest extends Component {
       </StickyContainer>
     )
   }
-}
-
-// TODO: remove .propTypes when parent also uses flow
-PullRequest.propTypes = {
-  dispatch: PropTypes.func.isRequired,
-  isFetching: PropTypes.bool.isRequired,
-  params: PropTypes.object.isRequired,
-  persona: PropTypes.oneOf([DEVELOPER_PERSONA, MANAGER_PERSONA, GUARDIAN_PERSONA]).isRequired,
-  pullRequest: PropTypes.object,
 }
 
 export default connect(

--- a/src/containers/Project/PullRequest/index.js
+++ b/src/containers/Project/PullRequest/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import Helmet from 'react-helmet'
 import { StickyContainer } from 'react-sticky'
@@ -30,16 +30,7 @@ type Props = {
   pullRequest: ?PullRequestGraphType,
 };
 
-export type Props = {
-  dispatch: Function,
-  isFetching: boolean,
-  params: Object,
-  persona: DEVELOPER_PERSONA | MANAGER_PERSONA | GUARDIAN_PERSONA,
-  pullRequest?: Object,
-};
-
 class PullRequest extends Component {
-  props: Props;
 
   componentDidMount() {
     const { dispatch, params } = this.props
@@ -47,7 +38,7 @@ class PullRequest extends Component {
     dispatch(actions.fetchStart(pullRequestId))
   }
 
-  props: Props;
+  props: Props
 
   render() {
     const { isFetching, pullRequest, persona } = this.props

--- a/src/containers/Project/PullRequests/index.js
+++ b/src/containers/Project/PullRequests/index.js
@@ -1,16 +1,15 @@
-// TODO: add flow annotations
+/* @flow */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import Helmet from 'react-helmet'
-import {
-  Filter,
-  BranchSelect,
-  PullRequestList,
-} from 'components'
+
 import { Col, Row, Button, ButtonGroup } from 'react-bootstrap'
 import { connect } from 'react-redux'
-// import { fetchUserPRs, fetchUserReviewPRs } from 'redux-modules/user'
 import { Sticky, StickyContainer } from 'react-sticky'
+
+import Filter from 'components/Filter'
+import BranchSelect from 'components/BranchSelect'
+import PullRequestList from 'components/PullRequestList'
 import { PullRequestsDataList } from '../../../api/testPullRequest'
 import { sort } from '../../../api/testData'
 
@@ -22,23 +21,23 @@ const approveButtonStyle = {
 
 
 export type Props = {
-  project_pullrequests?: // isFetching: PropTypes.bool.isRequired,
-  // errors: PropTypes.array,
-  // dispatch: PropTypes.func.isRequired,
-  Array<any>,
-  params?: // theme: PropTypes.object,
-  Object,
-};
+  project_pullrequests: Array<any>,
+  params: {
+    id: string,
+  },
+  items: Array<any>,
+}
 
 
 class PullRequests extends Component {
-  props: Props;
   componentDidMount() {
   //  const { dispatch } = this.props
       // TODO: should not be users PR fetch - should be replaced with the project pull requests
     // dispatch(fetchUserPRs())
     // dispatch(fetchUserReviewPRs())
   }
+
+  props: Props
 
   render() {
     const {

--- a/src/containers/Project/PullRequests/index.js
+++ b/src/containers/Project/PullRequests/index.js
@@ -137,7 +137,7 @@ class PullRequests extends Component {
             </div>
 
           </Sticky>
-          <PullRequestList data={PullRequestsDataList} />
+          <PullRequestList items={PullRequestsDataList} />
         </StickyContainer>
       </div>
     )

--- a/src/containers/Project/PullRequests/index.js
+++ b/src/containers/Project/PullRequests/index.js
@@ -21,7 +21,18 @@ const approveButtonStyle = {
 }
 
 
+export type Props = {
+  project_pullrequests?: // isFetching: PropTypes.bool.isRequired,
+  // errors: PropTypes.array,
+  // dispatch: PropTypes.func.isRequired,
+  Array<any>,
+  params?: // theme: PropTypes.object,
+  Object,
+};
+
+
 class PullRequests extends Component {
+  props: Props;
   componentDidMount() {
   //  const { dispatch } = this.props
       // TODO: should not be users PR fetch - should be replaced with the project pull requests
@@ -132,15 +143,6 @@ class PullRequests extends Component {
       </div>
     )
   }
-}
-
-PullRequests.propTypes = {
-  // isFetching: PropTypes.bool.isRequired,
-  // errors: PropTypes.array,
-  // dispatch: PropTypes.func.isRequired,
-  project_pullrequests: PropTypes.array,
-  // theme: PropTypes.object,
-  params: PropTypes.object,
 }
 
 export default connect(

--- a/src/containers/Project/Statistics/index.js
+++ b/src/containers/Project/Statistics/index.js
@@ -1,14 +1,16 @@
-export type Props = { // isFetching: PropTypes.bool.isRequired,
-// errorMessage: PropTypes.string,
-params?: Object };
+/* @flow */
 
-// TODO: add flow annotations
-
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import Helmet from 'react-helmet'
 
-function Statistics({ params: { prid } }) {
+export type Props = {
+  params: {
+    prid: string
+  }
+}
+
+function Statistics({ params: { prid } }: Props) {
   return (
     <div>
       <Helmet title="Statistics" />

--- a/src/containers/Project/Statistics/index.js
+++ b/src/containers/Project/Statistics/index.js
@@ -1,3 +1,7 @@
+export type Props = { // isFetching: PropTypes.bool.isRequired,
+// errorMessage: PropTypes.string,
+params?: Object };
+
 // TODO: add flow annotations
 
 import React, { PropTypes } from 'react'
@@ -11,12 +15,6 @@ function Statistics({ params: { prid } }) {
       <h3>Statistics {prid}</h3>
     </div>
   )
-}
-
-Statistics.propTypes = {
-  // isFetching: PropTypes.bool.isRequired,
-  // errorMessage: PropTypes.string,
-  params: PropTypes.object.isRequired,
 }
 
 export default connect(

--- a/src/containers/Projects/index.js
+++ b/src/containers/Projects/index.js
@@ -1,6 +1,6 @@
+// TODO: add flow annotations
 
-
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import Helmet from 'react-helmet'
 import { push } from 'react-router-redux'
 import CircularProgress from 'material-ui/CircularProgress'
@@ -19,13 +19,14 @@ export type Props = {
 };
 
 export class Projects extends Component {
-  props: Props;
   componentDidMount() {
     const { dispatch } = this.props
     this.clickHandler = this.clickHandler.bind(this)
     // todo: remove this from constructor
     dispatch(fetchProjects())
   }
+
+  props: Props
 
   clickHandler(value) {
     const { dispatch } = this.props

--- a/src/containers/Projects/index.js
+++ b/src/containers/Projects/index.js
@@ -10,7 +10,16 @@ import { fetchProjects } from 'ducks/projects'
 import { Sticky, StickyContainer } from 'react-sticky'
 import { Row, Col, Button, ButtonGroup } from 'react-bootstrap'
 
+export type Props = {
+  isFetching: boolean,
+  errors?: Array<any>,
+  projects: Array<any>,
+  dispatch: Function,
+  theme: Object,
+};
+
 export class Projects extends Component {
+  props: Props;
   componentDidMount() {
     const { dispatch } = this.props
     this.clickHandler = this.clickHandler.bind(this)
@@ -122,14 +131,6 @@ export class Projects extends Component {
       </div>
     )
   }
-}
-
-Projects.propTypes = {
-  isFetching: PropTypes.bool.isRequired,
-  errors: PropTypes.array,
-  projects: PropTypes.array.isRequired,
-  dispatch: PropTypes.func.isRequired,
-  theme: PropTypes.object.isRequired,
 }
 
 export default connect(

--- a/src/containers/PullRequests/AssignedPullRequestList/index.js
+++ b/src/containers/PullRequests/AssignedPullRequestList/index.js
@@ -7,7 +7,10 @@ import { selectors as sessionSelectors } from 'ducks/session/selectors'
 import PullRequestList from 'components/PullRequestList'
 import Toolbar from '../Toolbar'
 
+export type Props = { dispatch: Function };
+
 class AssignedPullRequestList extends Component {
+  props: Props;
   componentDidMount() {
     this.props.dispatch(actions.fetchUserAssignedPullRequests())
   }
@@ -20,10 +23,6 @@ class AssignedPullRequestList extends Component {
       </div>
     )
   }
-}
-
-AssignedPullRequestList.propTypes = {
-  dispatch: PropTypes.func.isRequired,
 }
 
 export default connect(

--- a/src/containers/PullRequests/AssignedPullRequestList/index.js
+++ b/src/containers/PullRequests/AssignedPullRequestList/index.js
@@ -1,19 +1,25 @@
+/* @flow */
+
 /* eslint-disable import/no-extraneous-dependencies */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { actions } from 'ducks/pullrequests'
 import { selectors as sessionSelectors } from 'ducks/session/selectors'
 import PullRequestList from 'components/PullRequestList'
 import Toolbar from '../Toolbar'
 
-export type Props = { dispatch: Function };
+export type Props = {
+  dispatch: Function,
+  items: Array<any>
+};
 
 class AssignedPullRequestList extends Component {
-  props: Props;
   componentDidMount() {
     this.props.dispatch(actions.fetchUserAssignedPullRequests())
   }
+
+  props: Props
 
   render() {
     return (
@@ -42,4 +48,3 @@ export default connect(
     items: sessionSelectors.getPullRequestsAssigned(state) || [],
   })
 )(AssignedPullRequestList)
-

--- a/src/containers/PullRequests/UserPullRequestList/index.js
+++ b/src/containers/PullRequests/UserPullRequestList/index.js
@@ -1,29 +1,33 @@
+/* @flow */
+
 /* eslint-disable import/no-extraneous-dependencies */
 
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { actions } from 'ducks/pullrequests'
 import { selectors as sessionSelectors } from 'ducks/session/selectors'
 import PullRequestList from 'components/PullRequestList'
 import Toolbar from '../Toolbar'
 
-export type Props = { dispatch: Function };
+export type Props = {
+  dispatch: Function,
+  items: Array<any>,
+}
 
 class UserPullRequestList extends Component {
   constructor(props: Props) {
     super(props)
     this.handleRemove = this.handleRemove.bind(this)
   }
-  props: Props;
   componentDidMount() {
     this.props.dispatch(actions.fetchUserPullRequests())
   }
 
+  props: Props
+
   handleRemove = (id) => {
 
   }
-
-  render
 
   render() {
     return (
@@ -52,4 +56,3 @@ export default connect(
     items: sessionSelectors.getPullRequests(state) || [],
   })
 )(UserPullRequestList)
-

--- a/src/containers/PullRequests/UserPullRequestList/index.js
+++ b/src/containers/PullRequests/UserPullRequestList/index.js
@@ -7,11 +7,14 @@ import { selectors as sessionSelectors } from 'ducks/session/selectors'
 import PullRequestList from 'components/PullRequestList'
 import Toolbar from '../Toolbar'
 
+export type Props = { dispatch: Function };
+
 class UserPullRequestList extends Component {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.handleRemove = this.handleRemove.bind(this)
   }
+  props: Props;
   componentDidMount() {
     this.props.dispatch(actions.fetchUserPullRequests())
   }
@@ -19,6 +22,8 @@ class UserPullRequestList extends Component {
   handleRemove = (id) => {
 
   }
+
+  render
 
   render() {
     return (
@@ -28,10 +33,6 @@ class UserPullRequestList extends Component {
       </div>
     )
   }
-}
-
-UserPullRequestList.propTypes = {
-  dispatch: PropTypes.func.isRequired,
 }
 
 export default connect(

--- a/src/containers/PullRequests/index.js
+++ b/src/containers/PullRequests/index.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 export type Props = {
   totalUserPRs?: number,
   totalUserAssignedPRs?: number,
@@ -5,7 +7,7 @@ export type Props = {
 
 /* eslint-disable */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import Helmet from 'react-helmet'
 import { connect } from 'react-redux'
 import { Tabs, Tab, Badge } from 'react-bootstrap'

--- a/src/containers/PullRequests/index.js
+++ b/src/containers/PullRequests/index.js
@@ -1,3 +1,8 @@
+export type Props = {
+  totalUserPRs?: number,
+  totalUserAssignedPRs?: number,
+};
+
 /* eslint-disable */
 
 import React, { PropTypes } from 'react'
@@ -42,11 +47,6 @@ function PullRequests(props) {
       </div>
     </div>
   )
-}
-
-PullRequests.propTypes = {
-  totalUserPRs: PropTypes.number.isRequired,
-  totalUserAssignedPRs: PropTypes.number.isRequired,
 }
 
 export default connect(


### PR DESCRIPTION
As we started using flow, we should use that instead of React.propTypes for our components. This gives us static type check instead of runtime when developing. 

This is the first stab of converting all `React.propTypes` to flow annotation. From now on stick to flow annotations. Just a plain 1 to 1 transformation.

I've done this using a codemod (https://github.com/skovhus/codemod-proptypes-to-flow/tree/fixes) and a lot of manual work...

### Bugs caught

Doing this actually caught a few bugs: 
- `changePersona` not being defined but called as an action
- https://github.com/Unity-Technologies/Tanto/pull/10/commits/42ebc9666ef2dca1a59cf9d56951cd08d3155c9c
- `import { selectors } from 'ducks/auth'` not existing for the badge components


### Next steps

For complex components I've disable flow and added a `// TODO: finish flow annotations`, please do that when you work with the component.

Start modelling the state tree as prop types, then we can use that in components.