### PR TITLE
Splitting pull request to speed up rendering + use URL instead of bootstrap

### DIFF
--- a/src/containers/Project/PullRequest/Layouts/LayoutDeveloper.js
+++ b/src/containers/Project/PullRequest/Layouts/LayoutDeveloper.js
@@ -1,24 +1,23 @@
 /* @flow */
 import React from 'react'
-import { Badge, Tabs, Tab } from 'react-bootstrap'
-import Scroll from 'react-scroll'
-
-import ChangesetFileList from 'components/ChangesetFileList'
-import ChangesetGroupedList from 'components/ChangesetGroupedList'
-import CodeDiffView from 'components/CodeDiffView'
-import IssuesList from 'components/IssuesList'
-import PullRequestDiscussion from 'components/PullRequestDiscussion'
-import PullRequestSummary from 'components/PullRequestSummary'
+import { Badge } from 'react-bootstrap'
+import { Link } from 'react-router'
 
 import type { PullRequestGraphType } from 'ducks/pullRequest'
 
-import {
-  PullRequestData, prChangesetList, prIssues,
-} from '../../../../api/testPullRequest'
+import CategoryModule from './common'
 
-const Element = Scroll.Element
 
-const tabTitle = (text, badge) => (
+const CATEGORIES = [
+  { url: 'summary', name: 'Summary' },
+  { url: 'discussion', name: 'Discussion' },
+  { url: 'files', name: 'Files' },
+  { url: 'changesets', name: 'Changesets' },
+  { url: 'issues', name: 'Issues' },
+  { url: 'diff', name: 'Diff' },
+]
+
+const TabTitle = ({ text, badge }) =>
   <div style={{ display: 'inline-flex' }}>
     <div style={{ float: 'left', marginRight: '5px' }}>
       {text}
@@ -31,59 +30,32 @@ const tabTitle = (text, badge) => (
       </div>
     }
   </div>
-)
 
+// FIXME: badge for changesets
 const downloadIcon = <i className="fa fa-download" aria-hidden="true" />
 
-const noop = () => {}
+// FIXME: badge for categories
+const Header = ({ currentCategory, rootPath }) =>
+  <ul className="nav nav-tabs" style={{ marginBottom: '24px' }}>
+    {CATEGORIES.map(c =>
+      <li className={c.url === currentCategory ? 'active' : ''} key={c.url}>
+        <Link to={`${rootPath}/${c.url}`}>
+          <TabTitle text={c.name} badge={c.url === 'changesets' ? downloadIcon : 1} />
+        </Link>
+      </li>
+    )}
+  </ul>
 
 export type Props = {
+  currentCategory: string,
   pullRequest: PullRequestGraphType,
+  rootPath: string,
 }
 
-// TODO: instead of tabs all of these should have their own URL
-const LayoutDeveloper = ({ pullRequest } : Props) =>
+const LayoutDeveloper = ({ currentCategory, pullRequest, rootPath } : Props) =>
   <div style={{ padding: '0 20px' }}>
-    <Tabs defaultActiveKey={0} id="layout-developer-tabs">
-      <Tab style={{ margin: '20px 0' }} eventKey={0} title="Summary">
-        <PullRequestSummary
-          onAddReviewer={noop}
-          onToggleReviewers={noop}
-          pullRequest={pullRequest}
-          toggleReviewers={false}
-        />
-      </Tab>
-      <Tab style={{ margin: '20px 0' }} eventKey={1} title={tabTitle('Discussion', 4)}>
-        <PullRequestDiscussion
-          onSaveComment={noop}
-        />
-      </Tab>
-      <Tab style={{ margin: '20px 0' }} eventKey={2} title="Files">
-        <div>
-          <ChangesetFileList files={pullRequest.files} />
-        </div>
-      </Tab>
-      <Tab
-        style={{ margin: '20px 0' }}
-        eventKey={3}
-        title={tabTitle('Changesets', downloadIcon)}
-      >
-        <div>
-          <ChangesetGroupedList accordion={false} data={prChangesetList} />
-        </div>
-      </Tab>
-      <Tab style={{ margin: '20px 0' }} eventKey={4} title={tabTitle('Issues', 2)}>
-        <div>
-          <IssuesList issues={prIssues} />
-        </div>
-      </Tab>
-      <Tab style={{ margin: '20px 0' }} eventKey={5} title="Diff">
-        <div>
-          <CodeDiffView files={PullRequestData} />
-        </div>
-      </Tab>
-    </Tabs>
-    <Element name="page-bottom" />
+    <Header currentCategory={currentCategory} rootPath={rootPath} />
+    <CategoryModule pullRequest={pullRequest} type={currentCategory} />
   </div>
 
 export default LayoutDeveloper

--- a/src/containers/Project/PullRequest/Layouts/LayoutGuardian.js
+++ b/src/containers/Project/PullRequest/Layouts/LayoutGuardian.js
@@ -3,22 +3,12 @@
 import React from 'react'
 import Scroll from 'react-scroll'
 
-import ChangesetFileList from 'components/ChangesetFileList'
-import ChangesetGroupedList from 'components/ChangesetGroupedList'
-import CodeDiffView from 'components/CodeDiffView'
 import Divider from 'components/Divider'
-import IssuesList from 'components/IssuesList'
-import PullRequestDiscussion from 'components/PullRequestDiscussion'
-import PullRequestSummary from 'components/PullRequestSummary'
-
 import type { PullRequestGraphType } from 'ducks/pullRequest'
-import {
-  PullRequestData, prChangesetList, prIssues,
-} from '../../../../api/testPullRequest'
+import CategoryModule from './common'
+
 
 const Element = Scroll.Element
-
-const noop = () => {}
 
 export type Props = {
   pullRequest: PullRequestGraphType,
@@ -29,44 +19,27 @@ const LayoutGuardian = ({ pullRequest }: Props) =>
   <div style={{ padding: '0 20px' }}>
     <Element name="page-top" className="element" />
     <Element name="summary" className="element">
-      <div>
-        <PullRequestSummary
-          onAddReviewer={noop}
-          onToggleReviewers={noop}
-          toggleReviewers={false}
-          pullRequest={pullRequest}
-        />
-      </div>
+      <CategoryModule pullRequest={pullRequest} type={'summary'} />
     </Element>
     <Element name="files" className="element">
       <Divider text="Files" />
-      <div>
-        <ChangesetFileList files={pullRequest.files} />
-      </div>
+      <CategoryModule pullRequest={pullRequest} type={'files'} />
     </Element>
     <Element name="changesets" className="element">
       <Divider text="Changesets" />
-      <div>
-        <ChangesetGroupedList accordion data={prChangesetList} />
-      </div>
+      <CategoryModule pullRequest={pullRequest} type={'changesets'} />
     </Element>
     <Element name="issues" className="element">
       <Divider text="Issues" />
-      <div>
-        <IssuesList issues={prIssues} />
-      </div>
+      <CategoryModule pullRequest={pullRequest} type={'issues'} />
     </Element>
     <Element name="discussion" className="element">
       <Divider text="Discussion" />
-      <PullRequestDiscussion
-        onSaveComment={noop}
-      />
+      <CategoryModule pullRequest={pullRequest} type={'discussion'} />
     </Element>
     <Element name="diff" className="element">
       <Divider text="Diff" />
-      <div>
-        <CodeDiffView files={PullRequestData} />
-      </div>
+      <CategoryModule pullRequest={pullRequest} type={'diff'} />
     </Element>
     <Element name="page-bottom" />
   </div>

--- a/src/containers/Project/PullRequest/Layouts/common.js
+++ b/src/containers/Project/PullRequest/Layouts/common.js
@@ -1,0 +1,56 @@
+/* @flow */
+import React from 'react'
+
+import ChangesetFileList from 'components/ChangesetFileList'
+import ChangesetGroupedList from 'components/ChangesetGroupedList'
+import CodeDiffView from 'components/CodeDiffView'
+import IssuesList from 'components/IssuesList'
+import PullRequestDiscussion from 'components/PullRequestDiscussion'
+import PullRequestSummary from 'components/PullRequestSummary'
+
+import type { PullRequestGraphType } from 'ducks/pullRequest'
+
+import {
+  PullRequestData, prChangesetList, prIssues,
+} from '../../../../api/testPullRequest'
+
+const noop = () => {}
+
+type Props = {
+  type: string,
+  pullRequest: PullRequestGraphType,
+}
+
+/**
+ * An attempt to share logic between developer and guardian layout.
+ */
+const CategoryModule = ({ type, pullRequest }: Props) =>
+  <div>
+    {type === 'summary' &&
+      <PullRequestSummary
+        onAddReviewer={noop}
+        onToggleReviewers={noop}
+        pullRequest={pullRequest}
+        toggleReviewers={false}
+      />
+    }
+    {type === 'discussion' &&
+      <PullRequestDiscussion
+        onSaveComment={noop}
+      />
+    }
+    {type === 'files' &&
+      <ChangesetFileList files={pullRequest.files} />
+    }
+    {type === 'changesets' &&
+      <ChangesetGroupedList accordion={false} data={prChangesetList} />
+    }
+    {type === 'issues' &&
+      <IssuesList issues={prIssues} />
+    }
+    {type === 'diff' &&
+      <CodeDiffView files={PullRequestData} />
+    }
+  </div>
+
+export default CategoryModule

--- a/src/containers/Project/PullRequest/index.js
+++ b/src/containers/Project/PullRequest/index.js
@@ -5,11 +5,7 @@ import { connect } from 'react-redux'
 import Helmet from 'react-helmet'
 import { StickyContainer } from 'react-sticky'
 
-import {
-  GUARDIAN_PERSONA,
-  DEVELOPER_PERSONA,
-  MANAGER_PERSONA,
-} from 'ducks/session'
+import { DEVELOPER_PERSONA } from 'ducks/session'
 import { actions } from 'ducks/pullRequest'
 import type { PullRequestGraphType } from 'ducks/pullRequest'
 
@@ -26,6 +22,11 @@ type Props = {
   params: {
     id: string,
     prid: string,
+    category: ?string,
+  },
+  location: {
+    pathname: string,
+    query: Object,
   },
   persona: 'DEVELOPER_PERSONA' | 'MANAGER_PERSONA' | 'GUARDIAN_PERSONA',
   pullRequest: ?PullRequestGraphType,
@@ -42,7 +43,7 @@ class PullRequest extends Component {
   props: Props
 
   render() {
-    const { isFetching, error, pullRequest, persona } = this.props
+    const { isFetching, error, pullRequest, persona, params, location } = this.props
 
     if (isFetching) {
       return <LoadingIcon />
@@ -63,21 +64,30 @@ class PullRequest extends Component {
       return <div>The requested pull request was not found...</div>
     }
 
+    let rootPath = location.pathname
+    if (params.category) {
+      // TODO: I don't like this, but react-router is not handling
+      // relative URLs, so we need to strip the category part of the url...
+      // There might be a better way. Or just using query params?
+      rootPath = rootPath.replace(new RegExp(`/${params.category}$`), '')
+    }
+
+    const defaultCategory = persona === DEVELOPER_PERSONA ? 'summary' : 'guardian'
+    const currentCategory = params.category || defaultCategory
+
     return (
       <StickyContainer style={{ fontSize: '14px' }}>
         <Helmet title={`Pull Request: ${pullRequest.title}`} />
         <StickyActionBar />
-        <div>
-          {persona === DEVELOPER_PERSONA &&
-            <LayoutDeveloper pullRequest={pullRequest} />
-          }
-          {persona === MANAGER_PERSONA &&
-            <LayoutGuardian pullRequest={pullRequest} />
-          }
-          {persona === GUARDIAN_PERSONA &&
-            <LayoutGuardian pullRequest={pullRequest} />
-          }
-        </div>
+        {currentCategory === 'guardian' || currentCategory === 'manager' ?
+          <LayoutGuardian pullRequest={pullRequest} />
+        :
+          <LayoutDeveloper
+            currentCategory={currentCategory}
+            pullRequest={pullRequest}
+            rootPath={rootPath}
+          />
+        }
       </StickyContainer>
     )
   }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -57,7 +57,7 @@ export default (store) => {
           <Route path="changelog" component={Changelog} />
           <Route path="pullrequests" component={ProjectPullRequests} />
           <Route onEnter={onPullRequestEnter}>
-            <Route path="pullrequest/:prid" component={PullRequest} />
+            <Route path="pullrequest/:prid(/:category)" component={PullRequest} />
           </Route>
           <Route onEnter={onChangesetEnter}>
             <Route path="changeset/:hash" component={Changeset} />


### PR DESCRIPTION
@kkateq please review. This uses the URL instead of keeping the state inside bootstrap tabs. Much faster rendering and shareable.

Old routing logic:
- pullrequest/:prid showed both developer (with tabs) and guardian/manager view

New routing logic
- pullrequest/:prid same as before, with developer tabs goes to sub pages, e.g. pullrequest/:prid/files