### PR TITLE
PullRequestSummary: Changes and Repositories

### DIFF
--- a/src/components/PullRequestSummary/PullRequestSummary.js
+++ b/src/components/PullRequestSummary/PullRequestSummary.js
@@ -9,6 +9,7 @@ import ListGroup from 'react-bootstrap/lib/ListGroup'
 import type { PullRequestGraphType } from 'services/ono/queries/pullRequest'
 import Reviewers from './Reviewers'
 import UserAvatar from '../UserAvatar'
+import { pluralizedText } from 'utils/text'
 
 import { prReviewers } from '../../api/testPullRequest'
 
@@ -42,16 +43,26 @@ const dangerColor = '#e96666'
 const headerColumnStyle = {
   textTransform: 'uppercase',
   color: '#10121b',
-  paddingTop: '10px',
+}
+
+export type PullRequestSummaryPaths = {
+  origin: {
+    url: string,
+    label: string,
+  },
+  target: {
+    url: string,
+    label: string,
+  }
 }
 
 type PullRequestSummaryProps = {
   onAddReviewer: Function,
   onToggleReviewers: Function,
+  paths: PullRequestSummaryPaths,
   pullRequest: PullRequestGraphType,
   toggleReviewers: boolean,
 }
-
 
 export const PullRequestHeader = ({ pullRequest } : { pullRequest: PullRequestGraphType }) =>
   <div style={{ display: 'inline-block' }}>
@@ -65,7 +76,7 @@ export const PullRequestHeader = ({ pullRequest } : { pullRequest: PullRequestGr
       </div>
       <span style={{ color: 'grey', fontSize: '13px' }}>
         created {moment(pullRequest.created).fromNow()}
-        by {pullRequest.owner.fullName} ({pullRequest.owner.username})
+        {' '} by {pullRequest.owner.fullName} ({pullRequest.owner.username})
       </span>
     </div>
   </div>
@@ -74,70 +85,43 @@ export const PullRequestHeader = ({ pullRequest } : { pullRequest: PullRequestGr
 export const ChangesSection = ({ pullRequest } : { pullRequest: PullRequestGraphType }) =>
   <ListGroupItem style={info}>
     <Row>
-      <Col md={2}>
+      <Col md={5}>
         <div style={headerColumnStyle}>
           Changes
         </div>
       </Col>
-      <Col md={3}>
+      <Col md={7}>
         <div>
-          <div>
-            {subHeader('Changes impact risk:')}
-            <div
-              style={{ color: 'rgb(142, 173, 181)', textTransform: 'uppercase' }}
-            >
-              High
-            </div>
-          </div>
+          {/* TODO: additions/deletions could be moved to backend */}
+          <span>{pluralizedText('file', 'files', pullRequest.files.length)} changed</span><br />
+          <span style={{ color: '#55a532' }}>
+            + {pullRequest.files.reduce((sum, f) => sum + f.stats.added, 0)}
+          </span>
+          <span style={{ color: '#bd2c00' }}>
+            {' '}− {pullRequest.files.reduce((sum, f) => sum + f.stats.deleted, 0)}
+          </span>
         </div>
       </Col>
-      <Col md={6}>
-        <div>
-          {subHeader('Delta:')}
-          <span style={{ color: '#91942b' }}> ~ 219 </span>
-          <span style={{ color: '#d36a9a' }}> - 8684 </span>
-          <span style={{ color: 'rgb(47, 199, 137)' }}> + 885 </span>
-        </div>
-      </Col>
-      <Col md={1} />
     </Row>
   </ListGroupItem>
 
 
-export const RepositoriesSection = ({ pullRequest } : { pullRequest: PullRequestGraphType }) =>
+export const RepositoriesSection = ({ pullRequest, paths } : {
+    paths: PullRequestSummaryPaths,
+    pullRequest: PullRequestGraphType
+}) =>
   <ListGroupItem style={info}>
     <Row>
-      <Col md={2}>
+      <Col md={5}>
         <div style={headerColumnStyle}>
           Repositories
         </div>
       </Col>
-      <Col md={3}>
+      <Col md={7}>
         <div>
-          {subHeader('Phase:')}
-          <div style={{ color: 'rgb(142, 173, 181)', textTransform: 'uppercase' }}>
-            DRAFT
-          </div>
-          <div style={{ fontSize: '12px' }}>(or headed to release)</div>
-        </div>
-      </Col>
-      <Col md={6}>
-        <div>
-          <div>
-            {subHeader('Origin:')}
-            <a href="unity/unity#ai/navmesh/builder-disabled">
-              unity/unity#ai/navmesh/builder-disabled
-            </a>
-          </div>
-          <div>
-            {subHeader('Target:')}
-            <a href="unity/unity#trunk">unity/unity#trunk</a>
-          </div>
-        </div>
-      </Col>
-      <Col md={1}>
-        <div style={{ color: '#dbdedf', float: 'right', fontSize: '20px' }}>
-          <i className="fa fa-pencil" aria-hidden="true" />
+          Origin: <a href={paths.origin.url}>{paths.origin.label}</a>
+          <br />
+          Target: <a href={paths.target.url}>{paths.target.label}</a>
         </div>
       </Col>
     </Row>
@@ -282,11 +266,11 @@ export const IssuesSection = ({ pullRequest } : { pullRequest: PullRequestGraphT
 
 
 const PullRequestSummary = (props: PullRequestSummaryProps) =>
-  <div name="summary" id="summary">
+  <div className="PullRequestSummary">
     <PullRequestHeader pullRequest={props.pullRequest} />
     <Row>
       <Col md={12}>
-        <ListGroup style={{ marginTop: '20px', fontSize: '13px' }}>
+        <ListGroup style={{ marginTop: '20px' }}>
           <ChangesSection {...props} />
           <RepositoriesSection {...props} />
           <ReviewersSection {...props} />

--- a/src/components/PullRequestSummary/PullRequestSummary.stories.js
+++ b/src/components/PullRequestSummary/PullRequestSummary.stories.js
@@ -1,4 +1,5 @@
 /* @flow */
+/* eslint-disable max-len */
 import React from 'react'
 import { storiesOf, action } from '@kadira/storybook'
 import { muiTheme } from 'storybook-addon-material-ui'
@@ -27,7 +28,46 @@ const pullRequestFixture = {
       username: 'sharron',
     },
   }],
-  files: [],
+  origin: {
+    url: 'unity/unity#my-pr',
+    branch: 'bar',
+    repository: {
+      name: 'foo',
+    },
+  },
+  target: {
+    url: 'unity/unity#trunk',
+    branch: 'bar',
+    repository: {
+      name: 'foo',
+    },
+  },
+  files: [
+    {
+      id: 'C--04c6e90faac2',
+      name: 'README.md',
+      oldName: 'README.md',
+      diff: 'diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ -1,1 +1,3 @@\n Foo bar\n+\n+!\n',
+      stats: {
+        added: 2,
+        deleted: 0,
+        binary: false,
+      },
+      operation: 'M',
+      comments: [],
+    },
+  ],
+}
+
+const pathsFixture = {
+  origin: {
+    url: '/unity/unity#my-pr',
+    label: 'unity/unity#my-pr',
+  },
+  target: {
+    url: '/unity/unity#trunk',
+    label: 'unity/unity#trunk',
+  },
 }
 
 storiesOf('PullRequestSummary', module)
@@ -36,6 +76,7 @@ storiesOf('PullRequestSummary', module)
     <PullRequestSummary
       onAddReviewer={action('onAddReviewer')}
       onToggleReviewers={action('onToggleReviewers')}
+      paths={pathsFixture}
       pullRequest={pullRequestFixture}
       toggleReviewers={false}
     />
@@ -58,6 +99,7 @@ storiesOf('PullRequestSummary Items', module)
   ))
   .add('RepositoriesSection', () => (
     <RepositoriesSection
+      paths={pathsFixture}
       pullRequest={pullRequestFixture}
     />
   ))
@@ -65,6 +107,7 @@ storiesOf('PullRequestSummary Items', module)
     <ReviewersSection
       onAddReviewer={action('onAddReviewer')}
       onToggleReviewers={action('onToggleReviewers')}
+      paths={pathsFixture}
       pullRequest={pullRequestFixture}
       toggleReviewers={false}
     />
@@ -73,6 +116,7 @@ storiesOf('PullRequestSummary Items', module)
     <ReviewersSection
       onAddReviewer={action('onAddReviewer')}
       onToggleReviewers={action('onToggleReviewers')}
+      paths={pathsFixture}
       pullRequest={pullRequestFixture}
       toggleReviewers
     />

--- a/src/pages/Project/PullRequest/Layouts/LayoutGuardian.js
+++ b/src/pages/Project/PullRequest/Layouts/LayoutGuardian.js
@@ -14,7 +14,6 @@ export type Props = {
   pullRequest: PullRequestGraphType,
 }
 
-// TODO: should be seperate URL from developer (simpel redirect if guardian)
 const LayoutGuardian = ({ pullRequest }: Props) =>
   <div style={{ padding: '0 20px' }}>
     <Element name="page-top" className="element" />

--- a/src/pages/Project/PullRequest/Layouts/common.js
+++ b/src/pages/Project/PullRequest/Layouts/common.js
@@ -10,6 +10,8 @@ import PullRequestSummary from 'components/PullRequestSummary'
 
 import type { PullRequestGraphType } from 'services/ono/queries/pullRequest'
 
+import { buildProjectLink } from 'routes/helpers'
+
 import {
   PullRequestData, prChangesetList, prIssues,
 } from '../../../../api/testPullRequest'
@@ -21,36 +23,51 @@ type Props = {
   pullRequest: PullRequestGraphType,
 }
 
+const getPath = originOrTarget => ({
+  url: buildProjectLink(originOrTarget.repository.name, originOrTarget.branch),
+  label: `${originOrTarget.repository.name}#${originOrTarget.branch}`,
+})
+
+
 /**
  * An attempt to share logic between developer and guardian layout.
  */
-const CategoryModule = ({ type, pullRequest }: Props) =>
-  <div>
-    {type === 'summary' &&
-      <PullRequestSummary
-        onAddReviewer={noop}
-        onToggleReviewers={noop}
-        pullRequest={pullRequest}
-        toggleReviewers={false}
-      />
-    }
-    {type === 'discussion' &&
-      <PullRequestDiscussion
-        onSaveComment={noop}
-      />
-    }
-    {type === 'files' &&
-      <ChangesetFileList files={pullRequest.files} />
-    }
-    {type === 'changesets' &&
-      <ChangesetGroupedList accordion={false} data={prChangesetList} />
-    }
-    {type === 'issues' &&
-      <IssuesList issues={prIssues} />
-    }
-    {type === 'diff' &&
-      <CodeDiffView files={PullRequestData} />
-    }
-  </div>
+const CategoryModule = ({ type, pullRequest }: Props) => {
+  const paths = {
+    origin: getPath(pullRequest.origin),
+    target: getPath(pullRequest.target),
+  }
+
+  return (
+    <div>
+      {type === 'summary' &&
+        <PullRequestSummary
+          onAddReviewer={noop}
+          onToggleReviewers={noop}
+          paths={paths}
+          pullRequest={pullRequest}
+          toggleReviewers={false}
+        />
+      }
+      {type === 'discussion' &&
+        <PullRequestDiscussion
+          onSaveComment={noop}
+        />
+      }
+      {type === 'files' &&
+        <ChangesetFileList files={pullRequest.files} />
+      }
+      {type === 'changesets' &&
+        <ChangesetGroupedList accordion={false} data={prChangesetList} />
+      }
+      {type === 'issues' &&
+        <IssuesList issues={prIssues} />
+      }
+      {type === 'diff' &&
+        <CodeDiffView files={PullRequestData} />
+      }
+    </div>
+  )
+}
 
 export default CategoryModule

--- a/src/routes/helpers/__tests__/index.js
+++ b/src/routes/helpers/__tests__/index.js
@@ -25,12 +25,12 @@ describe('routes helpers', () => {
 
   it('buildPullRequestLink', () => {
     expect(helpers.buildPullRequestLink('projectname', '1234'))
-      .equals('/projectname/pullrequests/1234')
+      .equals('/project/projectname/pullrequests/1234')
   })
 
   it('buildProjectLink', () => {
     expect(helpers.buildProjectLink('projectname', 'testbranch'))
-      .equals('/projectname?branch=testbranch')
+      .equals('/project/projectname?branch=testbranch')
   })
 
   it('buildProjectsLink', () => {

--- a/src/routes/helpers/index.js
+++ b/src/routes/helpers/index.js
@@ -16,9 +16,9 @@ export const breadcrumbItems = (pathname: string): Array<LinkType> => {
 
 export const groupPathFromPath = (path: string): string => path.replace(/^\/projects(\/)?/, '')
 export const buildPullRequestLink =
-  (projectName: string, id: string): string => (`/${projectName}/pullrequests/${id}`)
+  (projectName: string, id: string): string => (`/project/${projectName}/pullrequests/${id}`)
 export const buildProjectLink =
-  (projectName: string, branch: string): string => (`/${projectName}?branch=${branch}`)
+  (projectName: string, branch: string): string => (`/project/${projectName}?branch=${branch}`)
 export const buildProjectLinkNoBranch =
   (projectName: string): string => (`/project/${projectName}`)
 export const buildProjectsLink =

--- a/src/services/ono/queries/pullRequest/index.js
+++ b/src/services/ono/queries/pullRequest/index.js
@@ -19,6 +19,18 @@ query ($id: Int!) {
         username
       }
     }
+    origin {
+      branch
+      repository {
+        name
+      }
+    }
+    target {
+      branch
+      repository {
+        name
+      }
+    }
     files {
       id
       name
@@ -96,5 +108,17 @@ export type PullRequestGraphType = {
   created: string,
   owner: PullRequestUserType,
   reviewers: Array<PullRequestReviewerType>,
+  origin: {
+    branch: string,
+    repository: {
+      name: string,
+    },
+  },
+  target: {
+    branch: string,
+    repository: {
+      name: string,
+    },
+  },
   files: Array<File>,
 }


### PR DESCRIPTION

PullRequestSummary / PR meta data. This fixes CDS 89, 92 with correct CHANGES and REPOSITORIES columns.

### Before
![screen shot 2017-01-02 at 16 10 51](https://cloud.githubusercontent.com/assets/1260305/21591630/30d284a4-d106-11e6-9a84-e743da0c4c75.png)

### After
![screen shot 2017-01-02 at 16 43 00](https://cloud.githubusercontent.com/assets/1260305/21592379/4860fc98-d10d-11e6-87a7-04178c66d0da.png)

### TODO
- [ ] REPOSITORIES: `pullRequest.target.branch` is incorrect from the GraphQL server
