### PR TITLE
Slack HTTP(S) proxy fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "reselect": "^2.5.4",
     "scroll-behavior": "^0.3.2",
     "serve-favicon": "^2.3.0",
-    "slack": "^8.2.0",
+    "slack-proxy": "^8.2.8",
     "socket.io": "^1.3.7",
     "socket.io-client": "^1.3.7",
     "storybook-addon-material-ui": "^0.7.4",

--- a/src/server/controllers/__tests__/index.js
+++ b/src/server/controllers/__tests__/index.js
@@ -12,7 +12,10 @@ const noop = require('node-noop').noop
 
 describe('slack controller', () => {
 
-  beforeEach(() =>mockery.enable())
+  beforeEach(() => mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+  }))
   afterEach(() => mockery.disable())
 
   const redisCache = {}
@@ -101,7 +104,7 @@ describe('slack controller', () => {
     SLACK_TOKEN: 'some slack tocken'
   }
   mockery.registerMock('redis', redisMock)
-  mockery.registerMock('slack', slackMock)
+  mockery.registerMock('slack-proxy', slackMock)
   mockery.registerMock('server/config', envMock)
 
   it('prefetchSlackAvatars success', () => {
@@ -114,13 +117,7 @@ describe('slack controller', () => {
   it('prefetchSlackAvatars error', () => {
     cbEerror = error
     const prefetchSlackAvatars = require('../slack').prefetchSlackAvatars
-    expect(() => prefetchSlackAvatars()).to.throw(error)
-  })
-
-  it('prefetchSlackAvatars error', () => {
-    cbEerror = error
-    const prefetchSlackAvatars = require('../slack').prefetchSlackAvatars
-    expect(() => prefetchSlackAvatars()).to.throw(error)
+    expect(() => prefetchSlackAvatars()).not.to.throw(error)
   })
 })
 

--- a/src/server/controllers/slack.js
+++ b/src/server/controllers/slack.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint-disable */
 
-import slack from 'slack'
+import slack from 'slack-proxy'
 import redis from '../redis'
 
 const client = redis.client()
@@ -16,7 +16,9 @@ export const prefetchSlackAvatars = () => {
   const env = require('server/config')
   slack.users.list({ token: env.SLACK_TOKEN }, (err, data) => {
     if (err) {
-      throw err
+      //TODO: replace with proper logging
+      console.error(err)
+      return
     }
     if (data.ok) {
       const reducedProfiles =

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,6 +175,13 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+ajv@^4.9.1:
+  version "4.11.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.5.tgz#b6ee74657b993a01dce44b7944d56f485828d5bd"
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -1553,6 +1560,10 @@ case-sensitive-paths-webpack-plugin@^1.1.2:
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -3572,6 +3583,10 @@ gzip-size@^3.0.0:
   dependencies:
     duplexer "^0.1.1"
 
+har-schema@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
+
 har-validator@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
@@ -3580,6 +3595,13 @@ har-validator@~2.0.6:
     commander "^2.9.0"
     is-my-json-valid "^2.12.4"
     pinkie-promise "^2.0.0"
+
+har-validator@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
+  dependencies:
+    ajv "^4.9.1"
+    har-schema "^1.0.5"
 
 has-ansi@^0.1.0:
   version "0.1.0"
@@ -5501,6 +5523,10 @@ pbkdf2@^3.0.3:
   dependencies:
     create-hmac "^1.1.2"
 
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
 pidusage@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pidusage/-/pidusage-1.1.0.tgz#ffd58339a97aec470cff7cfe1a9853ec5cd415f8"
@@ -6102,6 +6128,10 @@ qs@6.2.0:
 qs@^6.1.0, qs@^6.2.0, qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
+
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 query-string@^3.0.0:
   version "3.0.3"
@@ -6758,6 +6788,33 @@ request@2, request@^2.55.0, request@^2.61.0, request@^2.74.0, request@^2.76.0, r
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
+request@^2.81.0:
+  version "2.81.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~4.2.1"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    performance-now "^0.2.0"
+    qs "~6.4.0"
+    safe-buffer "^5.0.1"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.0.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -6844,6 +6901,10 @@ rx-lite@^3.1.2:
 rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
+
+safe-buffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
 samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
@@ -6976,12 +7037,12 @@ sinon@^1.17.2:
     samsam "1.1.2"
     util ">=0.10.3 <1"
 
-slack@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/slack/-/slack-8.2.0.tgz#f79c15821e1f57544cc4c60f0bbed0104cf0943a"
+slack-proxy@^8.2.8:
+  version "8.2.8"
+  resolved "https://registry.yarnpkg.com/slack-proxy/-/slack-proxy-8.2.8.tgz#844e3a597de4f5c8141af6596d3595be7299aebf"
   dependencies:
-    tiny-json-http "^1.0.3"
-    ws "^1.1.1"
+    request "^2.81.0"
+    ws "^1.1.4"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -7391,10 +7452,6 @@ timers-browserify@^2.0.2:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-json-http@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-json-http/-/tiny-json-http-1.0.3.tgz#1b0601d8514cd10f7d5e6c2a4ab52d3b68784843"
-
 tlds@1.132.0:
   version "1.132.0"
   resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.132.0.tgz#85b8edba2e664531ccf6a69989be790c16777305"
@@ -7440,6 +7497,12 @@ tryit@^1.0.1:
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
 
 tunnel-agent@~0.4.1:
   version "0.4.3"
@@ -7906,9 +7969,16 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@1.1.1, ws@^1.1.1:
+ws@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.1.tgz#082ddb6c641e85d4bb451f03d52f06eabdb1f018"
+  dependencies:
+    options ">=0.0.5"
+    ultron "1.0.x"
+
+ws@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
I've forked `slack` API client and replaced  `tiny-json-http` HTTP client with `request` HTTP client which by default supports HTTP(S)_PROXY env settings. 